### PR TITLE
Make certificate verification form schema-driven

### DIFF
--- a/src/app/api/org/[slug]/certificates/route.ts
+++ b/src/app/api/org/[slug]/certificates/route.ts
@@ -13,13 +13,13 @@ export async function POST(
     if (auth instanceof NextResponse) return auth;
 
     const { volunteerId, hash, templateId } = await req.json();
-    if (!volunteerId || !hash) {
+    if (!volunteerId || !hash || !templateId) {
         return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
 
     try {
         const data = await hasuraAdmin<{ insert_certificates_one: { id: string } }>(
-            `mutation InsertCertificate($organizationId: uuid!, $volunteerId: String!, $hash: String!, $templateId: uuid) {
+            `mutation InsertCertificate($organizationId: uuid!, $volunteerId: String!, $hash: String!, $templateId: uuid!) {
                 insert_certificates_one(object: {
                     organization_id: $organizationId,
                     volunteer_id: $volunteerId,
@@ -27,7 +27,7 @@ export async function POST(
                     template_id: $templateId
                 }) { id }
             }`,
-            { organizationId: auth.organizationId, volunteerId, hash, templateId: templateId ?? null },
+            { organizationId: auth.organizationId, volunteerId, hash, templateId },
         );
         return NextResponse.json({ id: data.insert_certificates_one.id });
     } catch (e) {

--- a/src/app/api/org/[slug]/templates/[id]/route.ts
+++ b/src/app/api/org/[slug]/templates/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { hasuraAdmin } from "@/lib/server/hasura";
+import { resolveOrgIdBySlug } from "@/lib/server/apiAuth";
+import type { FormSchema } from "@/types/formSchema";
+
+export const runtime = "edge";
+
+/**
+ * Public lookup of a template's display metadata. The verify page calls this
+ * with `t=<id>` from the URL to render fields with proper labels. Does NOT
+ * expose base_pdf, pdfme schemas, or anything else internal.
+ */
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string; id: string }> },
+) {
+    const { slug, id } = await params;
+
+    try {
+        const organizationId = await resolveOrgIdBySlug(slug);
+        if (!organizationId) {
+            return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+        }
+
+        const data = await hasuraAdmin<{
+            templates: Array<{ id: string; name: string; form_schema: FormSchema }>;
+        }>(
+            `query GetTemplatePublic($id: uuid!, $organizationId: uuid!) {
+                templates(
+                    where: { id: { _eq: $id }, organization_id: { _eq: $organizationId } },
+                    limit: 1
+                ) { id name form_schema }
+            }`,
+            { id, organizationId },
+        );
+
+        const tmpl = data.templates[0];
+        if (!tmpl) {
+            return NextResponse.json({ error: "Template not found" }, { status: 404 });
+        }
+        return NextResponse.json({ template: tmpl });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}

--- a/src/app/api/org/[slug]/templates/route.ts
+++ b/src/app/api/org/[slug]/templates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hasuraAdmin } from "@/lib/server/hasura";
 import { requireOrgMemberBySlug } from "@/lib/server/apiAuth";
+import type { FormSchema } from "@/types/formSchema";
 
 export const runtime = "edge";
 
@@ -11,6 +12,7 @@ type TemplateRow = {
     description: string | null;
     base_pdf: string;
     schemas: unknown;
+    form_schema: FormSchema;
     is_default: boolean;
     created_at: string;
     updated_at: string;
@@ -28,7 +30,7 @@ export async function GET(
         const data = await hasuraAdmin<{ templates: TemplateRow[] }>(
             `query GetTemplates($organizationId: uuid!) {
                 templates(where: { organization_id: { _eq: $organizationId } }, order_by: { created_at: asc }) {
-                    id organization_id name description base_pdf schemas is_default created_at updated_at
+                    id organization_id name description base_pdf schemas form_schema is_default created_at updated_at
                 }
             }`,
             { organizationId: auth.organizationId },
@@ -47,7 +49,7 @@ export async function POST(
     const auth = await requireOrgMemberBySlug(req, slug);
     if (auth instanceof NextResponse) return auth;
 
-    const { name, description, basePdf, schemas, isDefault } = await req.json();
+    const { name, description, basePdf, schemas, formSchema, isDefault } = await req.json();
     if (!name || !basePdf || !schemas) {
         return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
@@ -70,14 +72,22 @@ export async function POST(
         }>(
             `mutation InsertTemplate(
                 $organizationId: uuid!, $name: String!, $description: String,
-                $basePdf: String!, $schemas: jsonb!, $isDefault: Boolean!
+                $basePdf: String!, $schemas: jsonb!, $formSchema: jsonb, $isDefault: Boolean!
             ) {
                 insert_templates_one(object: {
                     organization_id: $organizationId, name: $name, description: $description,
-                    base_pdf: $basePdf, schemas: $schemas, is_default: $isDefault
+                    base_pdf: $basePdf, schemas: $schemas, form_schema: $formSchema, is_default: $isDefault
                 }) { id created_at updated_at }
             }`,
-            { organizationId: auth.organizationId, name, description, basePdf, schemas, isDefault: isDefault ?? false },
+            {
+                organizationId: auth.organizationId,
+                name,
+                description,
+                basePdf,
+                schemas,
+                formSchema: formSchema ?? null,
+                isDefault: isDefault ?? false,
+            },
         );
         return NextResponse.json({ template: data.insert_templates_one });
     } catch (e) {

--- a/src/app/org/[orgSlug]/verify/OrgVerifyClient.tsx
+++ b/src/app/org/[orgSlug]/verify/OrgVerifyClient.tsx
@@ -1,20 +1,10 @@
 'use client'
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
-import { Box, Grid, TextField, Typography } from '@mui/material';
+import { Box, CircularProgress, Grid, TextField, Typography } from '@mui/material';
 import { canonicalHash } from '@/util/canonicalHash';
-import { buildCertParams } from '@/util/certParams';
 import { customTheme } from '@/app/style/customTheme';
-
-type ExtraRole = { groupName: string; startDate: string; endDate: string; role: string };
-type FormData = {
-    personName: string;
-    groupName: string;
-    startDate: string;
-    endDate: string;
-    role: string;
-    extraRoles: ExtraRole[];
-};
+import type { FormSchema, FormFieldSchema } from '@/types/formSchema';
 
 const OrgVerifyClient: React.FC = () => {
     const { orgSlug } = useParams<{ orgSlug: string }>();
@@ -25,20 +15,28 @@ const OrgVerifyClient: React.FC = () => {
 
     const [storedHash, setStoredHash] = useState<string | null | undefined>(undefined);
     const [verificationResult, setVerificationResult] = useState<'verified' | 'invalid' | null>(null);
+    const [formSchema, setFormSchema] = useState<FormSchema | null>(null);
+    const [schemaLoading, setSchemaLoading] = useState(!!templateId);
 
-    const [formData, setFormData] = useState<FormData>(() => ({
-        personName: searchParams.get('name') ?? '',
-        groupName: searchParams.get('group') ?? '',
-        startDate: searchParams.get('start') ?? '',
-        endDate: searchParams.get('end') ?? '',
-        role: searchParams.get('role') ?? '',
-        extraRoles: [1, 2, 3].map((i) => ({
-            groupName: searchParams.get(`group${i}`) ?? '',
-            startDate: searchParams.get(`start${i}`) ?? '',
-            endDate: searchParams.get(`end${i}`) ?? '',
-            role: searchParams.get(`role${i}`) ?? '',
-        })),
-    }));
+    // All URL params except 't' — includes 'id' (part of hash) and all cert fields
+    const [fields, setFields] = useState<Record<string, string>>(() => {
+        const result: Record<string, string> = {};
+        searchParams.forEach((value, key) => {
+            if (key !== 't') result[key] = value;
+        });
+        return result;
+    });
+
+    useEffect(() => {
+        if (!templateId) { setSchemaLoading(false); return; }
+        fetch(`/api/org/${encodeURIComponent(orgSlug)}/templates/${encodeURIComponent(templateId)}`)
+            .then((r) => r.json())
+            .then((json: { template?: { form_schema: FormSchema } }) => {
+                if (json.template?.form_schema) setFormSchema(json.template.form_schema);
+            })
+            .catch(() => {})
+            .finally(() => setSchemaLoading(false));
+    }, [orgSlug, templateId]);
 
     useEffect(() => {
         if (!volunteerId) { setStoredHash(null); return; }
@@ -51,21 +49,10 @@ const OrgVerifyClient: React.FC = () => {
     useEffect(() => {
         if (storedHash === undefined) return;
         if (!storedHash) { setVerificationResult('invalid'); return; }
-
-        const params = buildCertParams(templateId, {
-            id: volunteerId,
-            personName: formData.personName,
-            groupName: formData.groupName,
-            startDate: formData.startDate,
-            endDate: formData.endDate,
-            role: formData.role,
-            extraRole: formData.extraRoles,
-        });
-
-        canonicalHash(params).then((computed) => {
+        canonicalHash(new URLSearchParams(fields)).then((computed) => {
             setVerificationResult(computed === storedHash ? 'verified' : 'invalid');
         });
-    }, [formData, storedHash, templateId, volunteerId]);
+    }, [fields, storedHash]);
 
     const getColor = () => {
         if (verificationResult === 'verified') return colorTheme.primary.main;
@@ -73,26 +60,17 @@ const OrgVerifyClient: React.FC = () => {
         return colorTheme.secondary.main;
     };
 
-    const updateField = (key: keyof Omit<FormData, 'extraRoles'>, value: string) => {
-        setFormData((prev) => ({ ...prev, [key]: value }));
+    const updateField = (key: string, value: string) => {
+        setFields((prev) => ({ ...prev, [key]: value }));
     };
 
-    const updateExtraRole = (index: number, key: keyof ExtraRole, value: string) => {
-        setFormData((prev) => ({
-            ...prev,
-            extraRoles: prev.extraRoles.map((r, i) => (i === index ? { ...r, [key]: value } : r)),
-        }));
-    };
-
-    const visibleExtraRoles = useMemo(
-        () =>
-            formData.extraRoles
-                .map((r, i) => ({ r, i }))
-                .filter(({ i }) =>
-                    ['group', 'start', 'end', 'role'].some((k) => searchParams.has(`${k}${i + 1}`)),
-                ),
-        [formData.extraRoles, searchParams],
-    );
+    // Schema-driven: show only fields present in schema; hide optional ones absent from URL.
+    // Fallback (no template id or schema fetch failed): derive fields from URL params.
+    const visibleFields: FormFieldSchema[] = formSchema
+        ? formSchema.filter((f) => !f.optional || searchParams.has(f.key))
+        : Object.keys(fields)
+              .filter((k) => k !== 'id')
+              .map((k) => ({ key: k, label: k, type: 'text' as const }));
 
     return (
         <Box sx={{ border: `5px solid ${getColor()}`, padding: 1, borderRadius: 2, margin: 2 }}>
@@ -109,67 +87,25 @@ const OrgVerifyClient: React.FC = () => {
                     Endre feltene under for å verifisere mot lagret hash.
                 </Typography>
             </Grid>
-            <Box>
-                <Grid container spacing={2} paddingTop={2}>
-                    <Grid size={{ xs: 10, md: 12 }}>
-                        <TextField
-                            label="Navn"
-                            variant="outlined"
-                            fullWidth
-                            value={formData.personName}
-                            onChange={(e) => updateField('personName', e.target.value)}
-                        />
+            <Grid container spacing={2} paddingTop={2}>
+                {schemaLoading ? (
+                    <Grid size={{ xs: 12 }}>
+                        <CircularProgress size={24} />
                     </Grid>
-                </Grid>
-                <Grid container spacing={2} paddingTop={3}>
-                    <Grid size={{ xs: 5, md: 3 }}>
-                        <TextField label="Rolle" variant="outlined" fullWidth
-                            value={formData.role}
-                            onChange={(e) => updateField('role', e.target.value)} />
-                    </Grid>
-                    <Grid size={{ xs: 5, md: 3 }}>
-                        <TextField label="Gruppe" variant="outlined" fullWidth
-                            value={formData.groupName}
-                            onChange={(e) => updateField('groupName', e.target.value)} />
-                    </Grid>
-                    <Grid size={{ xs: 5, md: 3 }}>
-                        <TextField label="Startdato" variant="outlined" fullWidth
-                            value={formData.startDate}
-                            onChange={(e) => updateField('startDate', e.target.value)} />
-                    </Grid>
-                    <Grid size={{ xs: 5, md: 3 }}>
-                        <TextField label="Sluttdato" variant="outlined" fullWidth
-                            value={formData.endDate}
-                            onChange={(e) => updateField('endDate', e.target.value)} />
-                    </Grid>
-                </Grid>
-                {visibleExtraRoles.map(({ r, i }) => (
-                    <Box key={i} sx={{ marginTop: 2 }}>
-                        <Grid container spacing={2}>
-                            <Grid size={{ xs: 5, md: 3 }}>
-                                <TextField label={`Rolle ${i + 1}`} variant="outlined" fullWidth
-                                    value={r.role}
-                                    onChange={(e) => updateExtraRole(i, 'role', e.target.value)} />
-                            </Grid>
-                            <Grid size={{ xs: 5, md: 3 }}>
-                                <TextField label={`Gruppe ${i + 1}`} variant="outlined" fullWidth
-                                    value={r.groupName}
-                                    onChange={(e) => updateExtraRole(i, 'groupName', e.target.value)} />
-                            </Grid>
-                            <Grid size={{ xs: 5, md: 3 }}>
-                                <TextField label={`Startdato ${i + 1}`} variant="outlined" fullWidth
-                                    value={r.startDate}
-                                    onChange={(e) => updateExtraRole(i, 'startDate', e.target.value)} />
-                            </Grid>
-                            <Grid size={{ xs: 5, md: 3 }}>
-                                <TextField label={`Sluttdato ${i + 1}`} variant="outlined" fullWidth
-                                    value={r.endDate}
-                                    onChange={(e) => updateExtraRole(i, 'endDate', e.target.value)} />
-                            </Grid>
+                ) : (
+                    visibleFields.map((field) => (
+                        <Grid key={field.key} size={{ xs: 12, sm: 6, md: 3 }}>
+                            <TextField
+                                label={field.label}
+                                variant="outlined"
+                                fullWidth
+                                value={fields[field.key] ?? ''}
+                                onChange={(e) => updateField(field.key, e.target.value)}
+                            />
                         </Grid>
-                    </Box>
-                ))}
-            </Box>
+                    ))
+                )}
+            </Grid>
         </Box>
     );
 };

--- a/src/types/formSchema.ts
+++ b/src/types/formSchema.ts
@@ -1,0 +1,33 @@
+export type FormFieldSchema = {
+    key: string;
+    label: string;
+    type: 'text' | 'date';
+    optional?: boolean;
+};
+
+export type FormSchema = FormFieldSchema[];
+
+/**
+ * The default form schema matches the hardcoded Volunteer shape. Backfilled
+ * onto every existing template via DB migration; new templates inherit this
+ * via the DB column DEFAULT until PR 2 introduces a template-aware form.
+ */
+export const VOLUNTEER_FORM_SCHEMA: FormSchema = [
+    { key: 'name', label: 'Navn', type: 'text' },
+    { key: 'group', label: 'Gruppe', type: 'text' },
+    { key: 'start', label: 'Startdato', type: 'date' },
+    { key: 'end', label: 'Sluttdato', type: 'date' },
+    { key: 'role', label: 'Rolle', type: 'text' },
+    { key: 'group1', label: 'Gruppe 1', type: 'text', optional: true },
+    { key: 'start1', label: 'Startdato 1', type: 'date', optional: true },
+    { key: 'end1', label: 'Sluttdato 1', type: 'date', optional: true },
+    { key: 'role1', label: 'Rolle 1', type: 'text', optional: true },
+    { key: 'group2', label: 'Gruppe 2', type: 'text', optional: true },
+    { key: 'start2', label: 'Startdato 2', type: 'date', optional: true },
+    { key: 'end2', label: 'Sluttdato 2', type: 'date', optional: true },
+    { key: 'role2', label: 'Rolle 2', type: 'text', optional: true },
+    { key: 'group3', label: 'Gruppe 3', type: 'text', optional: true },
+    { key: 'start3', label: 'Startdato 3', type: 'date', optional: true },
+    { key: 'end3', label: 'Sluttdato 3', type: 'date', optional: true },
+    { key: 'role3', label: 'Rolle 3', type: 'text', optional: true },
+];

--- a/src/types/templateTypes.ts
+++ b/src/types/templateTypes.ts
@@ -1,4 +1,5 @@
 import type { Schema } from '@pdfme/common';
+import type { FormSchema } from './formSchema';
 
 export interface PDFTemplate {
     id?: string;
@@ -6,6 +7,7 @@ export interface PDFTemplate {
     description?: string;
     basePdf: string;
     schemas: Schema[][];
+    formSchema?: FormSchema;
     isDefault: boolean;
     createdAt: Date;
     updatedAt: Date;

--- a/src/util/databaseInteractions/templateService.ts
+++ b/src/util/databaseInteractions/templateService.ts
@@ -1,5 +1,6 @@
 import { authHeader } from '@/lib/nhost';
 import type { PDFTemplate } from '@/types/templateTypes';
+import type { FormSchema } from '@/types/formSchema';
 import type { Template } from '@pdfme/common';
 
 type TemplateRow = {
@@ -9,6 +10,7 @@ type TemplateRow = {
     description: string | null;
     base_pdf: string;
     schemas: Template['schemas'];
+    form_schema: FormSchema | null;
     is_default: boolean;
     created_at: string;
     updated_at: string;
@@ -26,6 +28,7 @@ export async function getTemplates(orgSlug: string): Promise<PDFTemplate[]> {
         description: row.description ?? undefined,
         basePdf: row.base_pdf,
         schemas: row.schemas,
+        formSchema: row.form_schema ?? undefined,
         isDefault: row.is_default,
         createdAt: new Date(row.created_at),
         updatedAt: new Date(row.updated_at),
@@ -44,6 +47,7 @@ export async function saveTemplate(
             description: template.description,
             basePdf: template.basePdf,
             schemas: template.schemas,
+            formSchema: template.formSchema,
             isDefault: template.isDefault,
         }),
     });


### PR DESCRIPTION
## Summary

Refactor the organization certificate verification page to be schema-driven rather than hardcoded. Templates now carry a `form_schema` field that describes which fields to display and how to label them. The verify page fetches this schema and renders fields dynamically, with a fallback to URL-parameter-derived fields for templates without a schema.

## Key Changes

- **New type definitions** (`src/types/formSchema.ts`):
  - `FormFieldSchema`: describes a single form field (key, label, type, optional flag)
  - `FormSchema`: array of field schemas
  - `VOLUNTEER_FORM_SCHEMA`: default schema matching the legacy hardcoded volunteer shape (backfilled onto all existing templates via DB migration)

- **New public API endpoint** (`src/app/api/org/[slug]/templates/[id]/route.ts`):
  - GET endpoint that returns a template's `form_schema` and metadata (name, id)
  - Does NOT expose internal fields (base_pdf, pdfme schemas, etc.)
  - Used by the verify page to fetch display metadata

- **Refactored verify page** (`src/app/org/[orgSlug]/verify/OrgVerifyClient.tsx`):
  - Removed hardcoded `FormData` type and `buildCertParams` utility
  - Now stores all URL params (except `t`) in a flat `fields` record
  - Fetches `form_schema` from the template API if `templateId` is present
  - Renders fields dynamically based on schema; shows loading spinner while fetching
  - Falls back to deriving fields from URL params if no schema or fetch fails
  - Simplified hash verification: passes `URLSearchParams(fields)` directly to `canonicalHash`

- **Updated template endpoints** (`src/app/api/org/[slug]/templates/route.ts`):
  - GET: now includes `form_schema` in template rows
  - POST: accepts optional `formSchema` parameter when creating templates

- **Updated certificate endpoint** (`src/app/api/org/[slug]/certificates/route.ts`):
  - Made `templateId` required in the mutation (was optional)

- **Updated type definitions** (`src/types/templateTypes.ts`, `src/util/databaseInteractions/templateService.ts`):
  - Added `formSchema?: FormSchema` field to `PDFTemplate` interface
  - Updated template service to include `form_schema` in queries

## Notable Implementation Details

- The verify page now uses a generic `fields` record instead of a typed `FormData` object, allowing it to handle any schema without code changes
- Schema-driven rendering respects the `optional` flag: optional fields are only shown if they appear in the URL
- The fallback behavior (no template ID or schema fetch failure) derives fields from URL params, maintaining backward compatibility
- Hash computation remains unchanged: `canonicalHash` still drops `t` and sorts params, ensuring existing certificates continue to verify
- Loading state prevents form submission while schema is being fetched

https://claude.ai/code/session_0142AspkipemJMg1ggSqfQzg