### PR TITLE
Designer ergonomics: background picker, quick-add, slugify, live status

### DIFF
--- a/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
+++ b/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
@@ -11,13 +11,14 @@ import {
     Typography,
 } from '@mui/material';
 import { Designer } from '@pdfme/ui';
-import { text, image, barcodes } from '@pdfme/schemas';
+import { text, image, barcodes, rectangle } from '@pdfme/schemas';
 import { Template, BLANK_PDF } from '@pdfme/common';
 import { saveTemplate, getTemplates, fromPdfmeTemplate } from '@/util/databaseInteractions/templateService';
 import { listOrgAssets } from '@/util/databaseInteractions/orgAssets';
 import { deriveFormSchema } from '@/util/templateFields';
 import { validateTemplateForSave } from '@/util/validateTemplate';
 import { buildPreviewPdfUrl } from '@/util/previewPdf';
+import { applyBackground, readBackgroundColor, BACKGROUNDS } from '@/util/templateBackground';
 import type { PDFTemplate } from '@/types/templateTypes';
 import type { FieldBindings } from '@/types/fieldBindings';
 import type { OrgAsset } from '@/types/orgAssets';
@@ -84,6 +85,7 @@ export default function DesignerComponent({
                 Text: text,
                 Image: image,
                 QR: barcodes.qrcode,
+                Rectangle: rectangle,
             },
         });
 
@@ -253,6 +255,22 @@ export default function DesignerComponent({
     // itself isn't used.
     void schemaRev;
 
+    const currentBackground = (() => {
+        if (!designerRef.current) return null;
+        try {
+            return readBackgroundColor(designerRef.current.getTemplate());
+        } catch {
+            return null;
+        }
+    })();
+
+    const handlePickBackground = (color: string | null) => {
+        if (!designerRef.current) return;
+        const patched = applyBackground(designerRef.current.getTemplate(), color);
+        designerRef.current.updateTemplate(patched);
+        setSchemaRev((r) => r + 1);
+    };
+
     return (
         <>
             <Paper sx={{ p: 2, mb: 2 }}>
@@ -298,6 +316,38 @@ export default function DesignerComponent({
                         ))}
                     </Box>
                 )}
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                        Bakgrunn:
+                    </Typography>
+                    <Box
+                        onClick={() => handlePickBackground(null)}
+                        title="Ingen"
+                        sx={{
+                            width: 28, height: 28, borderRadius: '50%', cursor: 'pointer',
+                            border: currentBackground === null ? '2px solid' : '1px dashed',
+                            borderColor: currentBackground === null ? 'primary.main' : 'grey.400',
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            bgcolor: 'transparent', fontSize: 18, color: 'grey.500',
+                        }}
+                    >
+                        ✕
+                    </Box>
+                    {BACKGROUNDS.map((b) => (
+                        <Box
+                            key={b.id}
+                            onClick={() => handlePickBackground(b.color)}
+                            title={b.name}
+                            sx={{
+                                width: 28, height: 28, borderRadius: '50%', cursor: 'pointer',
+                                bgcolor: b.color,
+                                border: currentBackground === b.color ? '2px solid' : '1px solid',
+                                borderColor: currentBackground === b.color ? 'primary.main' : 'grey.400',
+                            }}
+                        />
+                    ))}
+                </Box>
             </Paper>
 
             <Paper sx={{ p: 2 }}>

--- a/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
+++ b/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
@@ -19,6 +19,14 @@ import { deriveFormSchema } from '@/util/templateFields';
 import { validateTemplateForSave } from '@/util/validateTemplate';
 import { buildPreviewPdfUrl } from '@/util/previewPdf';
 import { applyBackground, readBackgroundColor, BACKGROUNDS } from '@/util/templateBackground';
+import {
+    quickAddBodyText,
+    quickAddBrand,
+    quickAddLogo,
+    quickAddQrCode,
+    quickAddSignature,
+    type QuickAddResult,
+} from '@/util/quickAddFields';
 import type { PDFTemplate } from '@/types/templateTypes';
 import type { FieldBindings } from '@/types/fieldBindings';
 import type { OrgAsset } from '@/types/orgAssets';
@@ -271,6 +279,18 @@ export default function DesignerComponent({
         setSchemaRev((r) => r + 1);
     };
 
+    const handleQuickAdd = (factory: (schemas: Template['schemas']) => QuickAddResult) => {
+        if (!designerRef.current) return;
+        const current = designerRef.current.getTemplate();
+        const { fields, bindings: newBindings } = factory(current.schemas);
+        if (fields.length === 0) return; // idempotent factories may return empty
+        const firstPage = [...(current.schemas[0] ?? []), ...fields];
+        const nextSchemas = [firstPage, ...current.schemas.slice(1)];
+        designerRef.current.updateTemplate({ ...current, schemas: nextSchemas });
+        setBindings((prev) => ({ ...prev, ...newBindings }));
+        setSchemaRev((r) => r + 1);
+    };
+
     return (
         <>
             <Paper sx={{ p: 2, mb: 2 }}>
@@ -316,6 +336,27 @@ export default function DesignerComponent({
                         ))}
                     </Box>
                 )}
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+                        Hurtig-felter:
+                    </Typography>
+                    <Button size="small" variant="outlined" onClick={() => handleQuickAdd(quickAddQrCode)}>
+                        + QR-kode
+                    </Button>
+                    <Button size="small" variant="outlined" onClick={() => handleQuickAdd(quickAddSignature)}>
+                        + Signatur
+                    </Button>
+                    <Button size="small" variant="outlined" onClick={() => handleQuickAdd(quickAddLogo)}>
+                        + Logo
+                    </Button>
+                    <Button size="small" variant="outlined" onClick={() => handleQuickAdd(quickAddBodyText)}>
+                        + Tekstblokk
+                    </Button>
+                    <Button size="small" variant="outlined" onClick={() => handleQuickAdd(quickAddBrand)}>
+                        + attester.no-merke
+                    </Button>
+                </Box>
 
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, flexWrap: 'wrap' }}>
                     <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>

--- a/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
+++ b/src/app/login/adminpage/[orgSlug]/edit_pdf/DesignerComponent.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
     Box,
     Button,
+    Chip,
     Paper,
     CircularProgress,
     Dialog,
@@ -10,6 +11,8 @@ import {
     DialogTitle,
     Typography,
 } from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Designer } from '@pdfme/ui';
 import { text, image, barcodes, rectangle } from '@pdfme/schemas';
 import { Template, BLANK_PDF } from '@pdfme/common';
@@ -17,6 +20,21 @@ import { saveTemplate, getTemplates, fromPdfmeTemplate } from '@/util/databaseIn
 import { listOrgAssets } from '@/util/databaseInteractions/orgAssets';
 import { deriveFormSchema } from '@/util/templateFields';
 import { validateTemplateForSave } from '@/util/validateTemplate';
+
+/**
+ * Boil the (often verbose) validateTemplateForSave error sentences down to
+ * a short chip label. Falls back to the count of missing items for
+ * anything we don't have a shorter phrasing for.
+ */
+function summariseValidationErrors(errors: string[]): string {
+    const short: string[] = [];
+    for (const e of errors) {
+        if (/QR-kode/i.test(e)) short.push('Mangler QR-kode');
+        else if (/attester\.no/i.test(e)) short.push('Mangler attester.no-tekst');
+        else short.push('Ufullstendig mal');
+    }
+    return short.join(' · ');
+}
 import { buildPreviewPdfUrl } from '@/util/previewPdf';
 import { applyBackground, readBackgroundColor, BACKGROUNDS } from '@/util/templateBackground';
 import {
@@ -69,6 +87,21 @@ export default function DesignerComponent({
     const [previewBusy, setPreviewBusy] = useState(false);
     // Bump this counter to force BindingsEditor to re-read the designer's schema.
     const [schemaRev, setSchemaRev] = useState(0);
+    // True whenever the in-memory template has been edited since the last save.
+    // Drives the beforeunload prompt + a soft visual cue on the Lagre button.
+    const [dirty, setDirty] = useState(false);
+
+    useEffect(() => {
+        if (!dirty) return;
+        const handler = (e: BeforeUnloadEvent) => {
+            // Modern browsers ignore the custom message and show their own.
+            // Returning a string is enough to trigger the prompt.
+            e.preventDefault();
+            e.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [dirty]);
 
     // Revoke the previous preview URL when it's replaced or the page unmounts
     // — otherwise the blob hangs around in memory.
@@ -97,7 +130,10 @@ export default function DesignerComponent({
             },
         });
 
-        designerRef.current.onChangeTemplate(() => setSchemaRev((r) => r + 1));
+        designerRef.current.onChangeTemplate(() => {
+            setSchemaRev((r) => r + 1);
+            setDirty(true);
+        });
 
         getTemplates(orgSlug).then(setExistingTemplates).catch((e) => {
             onError(`Kunne ikke laste maler: ${(e as Error).message}`);
@@ -150,6 +186,7 @@ export default function DesignerComponent({
                 schemas: [[]],
             });
             setSchemaRev((r) => r + 1);
+            setDirty(true);
         };
         reader.readAsDataURL(file);
     };
@@ -178,6 +215,7 @@ export default function DesignerComponent({
 
             await saveTemplate(orgSlug, data);
             onSuccess(`Mal "${templateName}" lagret!`);
+            setDirty(false);
 
             const templates = await getTemplates(orgSlug);
             setExistingTemplates(templates);
@@ -200,6 +238,8 @@ export default function DesignerComponent({
         setSchemaRev((r) => r + 1);
 
         onTemplateLoad(template.name, template.description || '', template.isDefault);
+        // Loading isn't editing — reset the unsaved-changes flag.
+        setDirty(false);
     };
 
     const handlePickStarter = (starter: StarterTemplate) => {
@@ -209,6 +249,9 @@ export default function DesignerComponent({
         setFormSchema(starter.formSchema);
         setSchemaRev((r) => r + 1);
         onTemplateLoad(starter.name, starter.description, false);
+        // Starting from a starter is a load, not an edit — admin hasn't
+        // changed anything yet. Mark fresh.
+        setDirty(false);
     };
 
     const handleExport = () => {
@@ -263,6 +306,29 @@ export default function DesignerComponent({
     // itself isn't used.
     void schemaRev;
 
+    // Which of the asset kinds the quick-add buttons assume a default for
+    // are NOT yet set up in this org's Innhold. Drives the small hint
+    // below the toolbar so admins know upfront why a slot may render
+    // empty after they click "+ Signatur".
+    const missingDefaults: string[] = (() => {
+        const haveDefault = (kind: OrgAsset['kind']) =>
+            assets.some((a) => a.kind === kind && a.isDefault);
+        const out: string[] = [];
+        if (!haveDefault('signature')) out.push('signatur');
+        if (!haveDefault('logo')) out.push('logo');
+        if (!haveDefault('body_text')) out.push('tekstblokk');
+        return out;
+    })();
+
+    const currentValidationErrors = (() => {
+        if (!designerRef.current) return ['Designeren laster …'];
+        try {
+            return validateTemplateForSave(designerRef.current.getTemplate());
+        } catch {
+            return [];
+        }
+    })();
+
     const currentBackground = (() => {
         if (!designerRef.current) return null;
         try {
@@ -277,6 +343,19 @@ export default function DesignerComponent({
         const patched = applyBackground(designerRef.current.getTemplate(), color);
         designerRef.current.updateTemplate(patched);
         setSchemaRev((r) => r + 1);
+        setDirty(true);
+    };
+
+    // Wrappers passed to BindingsEditor / SchemaEditor so admin edits in
+    // those panels also flip the unsaved-changes flag. Internal places
+    // (load, quick-add) bypass these and manage `dirty` explicitly.
+    const handleBindingsChange = (next: FieldBindings) => {
+        setBindings(next);
+        setDirty(true);
+    };
+    const handleFormSchemaChange = (next: FormSchema) => {
+        setFormSchema(next);
+        setDirty(true);
     };
 
     const handleQuickAdd = (factory: (schemas: Template['schemas']) => QuickAddResult) => {
@@ -289,6 +368,7 @@ export default function DesignerComponent({
         designerRef.current.updateTemplate({ ...current, schemas: nextSchemas });
         setBindings((prev) => ({ ...prev, ...newBindings }));
         setSchemaRev((r) => r + 1);
+        setDirty(true);
     };
 
     return (
@@ -313,8 +393,26 @@ export default function DesignerComponent({
                         onClick={handleSave}
                         disabled={saving || !templateName.trim()}
                     >
-                        {saving ? <CircularProgress size={20} /> : 'Lagre mal'}
+                        {saving ? <CircularProgress size={20} /> : (dirty ? 'Lagre mal *' : 'Lagre mal')}
                     </Button>
+
+                    {currentValidationErrors.length === 0 ? (
+                        <Chip
+                            icon={<CheckCircleIcon />}
+                            label="Klar til lagring"
+                            color="success"
+                            variant="outlined"
+                            size="small"
+                        />
+                    ) : (
+                        <Chip
+                            icon={<WarningAmberIcon />}
+                            label={summariseValidationErrors(currentValidationErrors)}
+                            color="warning"
+                            variant="outlined"
+                            size="small"
+                        />
+                    )}
 
                     <Button variant="outlined" color="secondary" onClick={handleExport}>
                         Eksporter JSON
@@ -357,6 +455,20 @@ export default function DesignerComponent({
                         + attester.no-merke
                     </Button>
                 </Box>
+
+                {missingDefaults.length > 0 && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                        Ingen standard {missingDefaults.join(' / ')} satt opp enda — feltet rendres tomt før du legger til en i{' '}
+                        <a
+                            href={`/login/adminpage/${orgSlug}/rediger`}
+                            target="_blank"
+                            rel="noreferrer"
+                            style={{ color: 'inherit' }}
+                        >
+                            Innhold ↗
+                        </a>.
+                    </Typography>
+                )}
 
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, flexWrap: 'wrap' }}>
                     <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
@@ -411,7 +523,7 @@ export default function DesignerComponent({
                     bindings={bindings}
                     assets={assets}
                     formSchema={formSchema}
-                    onChange={setBindings}
+                    onChange={handleBindingsChange}
                 />
             </Paper>
 
@@ -420,12 +532,12 @@ export default function DesignerComponent({
                     <Typography variant="h6">Skjema (innsender → data)</Typography>
                     <Button
                         size="small"
-                        onClick={() => setFormSchema(deriveFormSchema(currentSchemas, bindings))}
+                        onClick={() => handleFormSchemaChange(deriveFormSchema(currentSchemas, bindings))}
                     >
                         Auto-utled fra PDF
                     </Button>
                 </Box>
-                <SchemaEditor orgSlug={orgSlug} schema={formSchema} assets={assets} onChange={setFormSchema} />
+                <SchemaEditor orgSlug={orgSlug} schema={formSchema} assets={assets} onChange={handleFormSchemaChange} />
             </Paper>
 
             <StarterTemplatePicker

--- a/src/app/login/adminpage/[orgSlug]/edit_pdf/SchemaEditor.tsx
+++ b/src/app/login/adminpage/[orgSlug]/edit_pdf/SchemaEditor.tsx
@@ -46,12 +46,25 @@ export default function SchemaEditor({ orgSlug, schema, assets, onChange }: Prop
         onChange(next);
     };
 
+    // When the admin types a label, slugify it into the key automatically
+    // — as long as they haven't already hand-edited the key (`autoKey` is
+    // true). Drops the cognitive load of "what should I name this field"
+    // and keeps key + label in sync for new fields.
+    const updateLabel = (i: number, label: string) => {
+        const field = schema[i];
+        const patch: Partial<FormFieldSchema> = { label };
+        if (field.autoKey !== false) {
+            patch.key = slugifyKey(label) || field.key;
+        }
+        updateField(i, patch);
+    };
+
     const removeField = (i: number) => onChange(schema.filter((_, idx) => idx !== i));
 
     const addField = () =>
         onChange([
             ...schema,
-            { key: `field_${schema.length + 1}`, label: 'Nytt felt', type: 'text' },
+            { key: `field_${schema.length + 1}`, label: 'Nytt felt', type: 'text', autoKey: true },
         ]);
 
     return (
@@ -74,17 +87,22 @@ export default function SchemaEditor({ orgSlug, schema, assets, onChange }: Prop
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
                         <TextField
                             size="small"
-                            label="Nøkkel"
-                            value={field.key}
-                            onChange={(e) => updateField(i, { key: e.target.value.trim() })}
-                            sx={{ minWidth: 140 }}
+                            label="Etikett"
+                            value={field.label}
+                            onChange={(e) => updateLabel(i, e.target.value)}
+                            sx={{ minWidth: 180 }}
                         />
                         <TextField
                             size="small"
-                            label="Etikett"
-                            value={field.label}
-                            onChange={(e) => updateField(i, { label: e.target.value })}
-                            sx={{ minWidth: 180 }}
+                            label="Nøkkel"
+                            value={field.key}
+                            onChange={(e) =>
+                                updateField(i, {
+                                    key: slugifyKey(e.target.value),
+                                    autoKey: false,
+                                })
+                            }
+                            sx={{ minWidth: 140 }}
                         />
                         <FormControl size="small" sx={{ minWidth: 160 }}>
                             <InputLabel>Type</InputLabel>
@@ -177,6 +195,24 @@ export default function SchemaEditor({ orgSlug, schema, assets, onChange }: Prop
 }
 
 const MAX_PREVIEW = 8;
+
+/**
+ * Turn an admin-typed label ("Mottakers navn") into a safe key
+ * ("mottakers_navn"): lowercase, ASCII-only, underscores for runs of
+ * non-word chars. Used by the schema editor to keep key + label in sync
+ * for newly added fields without making admins think about it.
+ */
+function slugifyKey(label: string): string {
+    return label
+        .toLowerCase()
+        .replace(/[æå]/g, 'a')
+        .replace(/[ø]/g, 'o')
+        .replace(/[éè]/g, 'e')
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+}
 
 function LookupListPreview({ list, orgSlug }: { list: OrgAsset | undefined; orgSlug: string }) {
     const items = (list?.content as LookupListContent | undefined)?.items ?? [];

--- a/src/app/login/adminpage/[orgSlug]/edit_pdf/SchemaEditor.tsx
+++ b/src/app/login/adminpage/[orgSlug]/edit_pdf/SchemaEditor.tsx
@@ -19,6 +19,8 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import type { FormFieldSchema, FormFieldType, FormSchema } from '@/types/formSchema';
 import type { OrgAsset, LookupListContent } from '@/types/orgAssets';
 
@@ -60,6 +62,14 @@ export default function SchemaEditor({ orgSlug, schema, assets, onChange }: Prop
     };
 
     const removeField = (i: number) => onChange(schema.filter((_, idx) => idx !== i));
+
+    const moveField = (i: number, dir: -1 | 1) => {
+        const j = i + dir;
+        if (j < 0 || j >= schema.length) return;
+        const next = [...schema];
+        [next[i], next[j]] = [next[j], next[i]];
+        onChange(next);
+    };
 
     const addField = () =>
         onChange([
@@ -129,6 +139,22 @@ export default function SchemaEditor({ orgSlug, schema, assets, onChange }: Prop
                             }
                             label="Valgfritt"
                         />
+                        <IconButton
+                            size="small"
+                            onClick={() => moveField(i, -1)}
+                            disabled={i === 0}
+                            aria-label="Flytt opp"
+                        >
+                            <ArrowUpwardIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                            size="small"
+                            onClick={() => moveField(i, 1)}
+                            disabled={i === schema.length - 1}
+                            aria-label="Flytt ned"
+                        >
+                            <ArrowDownwardIcon fontSize="small" />
+                        </IconButton>
                         <IconButton color="error" onClick={() => removeField(i)}>
                             <DeleteIcon />
                         </IconButton>

--- a/src/app/login/adminpage/generatePDF.ts
+++ b/src/app/login/adminpage/generatePDF.ts
@@ -1,4 +1,4 @@
-import { barcodes, image, text } from '@pdfme/schemas';
+import { barcodes, image, text, rectangle } from '@pdfme/schemas';
 import { generate } from '@pdfme/generator';
 import { Template } from '@pdfme/common';
 import { getPdfInput } from '@/app/login/adminpage/getPDFInput';
@@ -33,7 +33,7 @@ export const generatePDF = async (
     const pdf = await generate({
         template,
         inputs: pdfInput,
-        plugins: { text, image, qrcode: barcodes.qrcode },
+        plugins: { text, image, qrcode: barcodes.qrcode, rectangle },
     });
     const filename = data.name ? `${data.name}_attest.pdf` : `attest_${submissionId}.pdf`;
     const blob = new Blob([new Uint8Array(pdf.buffer)], { type: 'application/pdf' });

--- a/src/types/formSchema.ts
+++ b/src/types/formSchema.ts
@@ -12,6 +12,13 @@ export type FormFieldSchema = {
      */
     options?: string[];
     optionsFromAsset?: string;
+    /**
+     * UX-only flag: when true (default for new fields), the schema editor
+     * slugifies the label into the key automatically as the admin types.
+     * Setting `key` directly flips this off so subsequent label edits
+     * don't clobber the admin's chosen key.
+     */
+    autoKey?: boolean;
 };
 
 export type FormSchema = FormFieldSchema[];

--- a/src/util/databaseInteractions/templateService.ts
+++ b/src/util/databaseInteractions/templateService.ts
@@ -109,7 +109,10 @@ export function fromPdfmeTemplate(
         formSchema?: FormSchema;
     },
 ): Omit<PDFTemplate, 'id' | 'createdAt' | 'updatedAt'> {
-    const fieldBindings = options?.fieldBindings ?? {};
+    const fieldBindings = autoBindSystemSlots(
+        pdfmeTemplate.schemas,
+        options?.fieldBindings ?? {},
+    );
     const formSchema = options?.formSchema ?? deriveFormSchema(pdfmeTemplate.schemas, fieldBindings);
     return {
         name,
@@ -120,4 +123,36 @@ export function fromPdfmeTemplate(
         fieldBindings,
         isDefault: options?.isDefault ?? false,
     };
+}
+
+/**
+ * Pdfme field names that, by convention, map directly to a system slot
+ * (resolveBinding's `system` source). Auto-wire these on save so admins
+ * don't have to open the bindings editor for the obvious ones — placing
+ * a qr_code field is signal enough that it should hold the verify URL.
+ */
+const SYSTEM_SLOT_BY_NAME: Record<string, 'qr_code' | 'qr_info' | 'qr_page' | 'today'> = {
+    qr_code: 'qr_code',
+    qr_info: 'qr_info',
+    qr_page: 'qr_page',
+    today: 'today',
+    signature_date: 'today',
+};
+
+function autoBindSystemSlots(
+    schemas: Template['schemas'],
+    existing: FieldBindings,
+): FieldBindings {
+    const next: FieldBindings = { ...existing };
+    for (const page of schemas ?? []) {
+        for (const field of page ?? []) {
+            const name = field?.name;
+            if (typeof name !== 'string') continue;
+            if (next[name]) continue;
+            const slot = SYSTEM_SLOT_BY_NAME[name];
+            if (!slot) continue;
+            next[name] = { source: 'system', system: slot };
+        }
+    }
+    return next;
 }

--- a/src/util/previewPdf.ts
+++ b/src/util/previewPdf.ts
@@ -1,5 +1,5 @@
 import { generate } from '@pdfme/generator';
-import { barcodes, image, text } from '@pdfme/schemas';
+import { barcodes, image, text, rectangle } from '@pdfme/schemas';
 import type { Template } from '@pdfme/common';
 import type { FieldBindings } from '@/types/fieldBindings';
 import type { FormSchema } from '@/types/formSchema';

--- a/src/util/quickAddFields.ts
+++ b/src/util/quickAddFields.ts
@@ -1,0 +1,142 @@
+import type { Template, Schema } from '@pdfme/common';
+import type { FieldBindings } from '@/types/fieldBindings';
+
+/**
+ * Quick-add presets for the designer toolbar. Each one returns the
+ * pdfme schema fields to drop in plus the field_bindings patches that
+ * wire them up. The whole point: leverage what admins have already
+ * uploaded — the default signature, default logo, default body-text —
+ * so dropping a signature field doesn't need a follow-up trip to the
+ * bindings editor.
+ *
+ * Position cascades on repeated clicks: a second "+ Signatur" places
+ * itself next to the first instead of stacking on top.
+ */
+
+export type QuickAddResult = {
+    fields: Schema[];
+    bindings: FieldBindings;
+};
+
+export function quickAddQrCode(schemas: Template['schemas']): QuickAddResult {
+    const n = countByPrefix(schemas, 'qr_code');
+    const name = n === 0 ? 'qr_code' : `qr_code_${n + 1}`;
+    return {
+        fields: [{
+            name,
+            type: 'qrcode',
+            content: 'https://attester.no',
+            position: { x: 160 - n * 4, y: 220 },
+            width: 28,
+            height: 28,
+            rotate: 0,
+        } as Schema],
+        bindings: { [name]: { source: 'system', system: 'qr_code' } },
+    };
+}
+
+export function quickAddSignature(schemas: Template['schemas']): QuickAddResult {
+    const n = countByPrefix(schemas, 'signature_photo');
+    const baseX = 25 + n * 70;
+    const photoName = `signature_photo_${n + 1}`;
+    const labelName = `signature_name_${n + 1}`;
+    const roleName = `signature_role_${n + 1}`;
+    return {
+        fields: [
+            {
+                name: photoName,
+                type: 'image',
+                content: '',
+                position: { x: baseX, y: 215 },
+                width: 50,
+                height: 22,
+                rotate: 0,
+            } as Schema,
+            txt(labelName, '', { x: baseX, y: 240 }, 70, 5, { fontSize: 10 }),
+            txt(roleName, '', { x: baseX, y: 246 }, 70, 4, { fontSize: 8 }),
+        ],
+        bindings: {
+            [photoName]: { source: 'asset_default', kind: 'signature', position: n, subField: 'photo' },
+            [labelName]: { source: 'asset_default', kind: 'signature', position: n, subField: 'name' },
+            [roleName]:  { source: 'asset_default', kind: 'signature', position: n, subField: 'role' },
+        },
+    };
+}
+
+export function quickAddLogo(schemas: Template['schemas']): QuickAddResult {
+    const n = countByPrefix(schemas, 'logo');
+    const name = n === 0 ? 'logo' : `logo_${n + 1}`;
+    return {
+        fields: [{
+            name,
+            type: 'image',
+            content: '',
+            position: { x: 160 - n * 35, y: 15 },
+            width: 30,
+            height: 15,
+            rotate: 0,
+        } as Schema],
+        bindings: {
+            [name]: { source: 'asset_default', kind: 'logo', position: n, subField: 'image' },
+        },
+    };
+}
+
+export function quickAddBodyText(schemas: Template['schemas']): QuickAddResult {
+    const n = countByPrefix(schemas, 'body_text');
+    const name = n === 0 ? 'body_text' : `body_text_${n + 1}`;
+    return {
+        fields: [txt(name, '', { x: 20, y: 140 + n * 50 }, 170, 40, { fontSize: 11, lineHeight: 1.4 })],
+        bindings: {
+            [name]: { source: 'asset_default', kind: 'body_text', position: n, subField: 'text' },
+        },
+    };
+}
+
+export function quickAddBrand(schemas: Template['schemas']): QuickAddResult {
+    // Idempotent: if a brand field already exists, return nothing.
+    if (countByPrefix(schemas, 'brand') > 0) {
+        return { fields: [], bindings: {} };
+    }
+    return {
+        fields: [txt('brand', 'attester.no', { x: 20, y: 282 }, 170, 6, { fontSize: 9, alignment: 'center' })],
+        bindings: {},
+    };
+}
+
+function countByPrefix(schemas: Template['schemas'], prefix: string): number {
+    const names = new Set<string>();
+    for (const page of schemas ?? []) {
+        for (const field of page ?? []) {
+            const name = field?.name;
+            if (typeof name !== 'string') continue;
+            if (name === prefix || name.startsWith(prefix + '_')) names.add(name);
+        }
+    }
+    return names.size;
+}
+
+function txt(
+    name: string,
+    content: string,
+    position: { x: number; y: number },
+    width: number,
+    height: number,
+    extra: Partial<Schema> = {},
+): Schema {
+    return {
+        name,
+        type: 'text',
+        content,
+        position,
+        width,
+        height,
+        rotate: 0,
+        alignment: 'left',
+        verticalAlignment: 'top',
+        fontSize: 12,
+        lineHeight: 1.3,
+        characterSpacing: 0,
+        ...extra,
+    } as Schema;
+}

--- a/src/util/templateBackground.ts
+++ b/src/util/templateBackground.ts
@@ -1,0 +1,76 @@
+import type { Template, Schema } from '@pdfme/common';
+
+const BG_FIELD_NAME = '__background__';
+
+/**
+ * Background presets the admin can pick from in the designer. Each one
+ * is a fill color applied to a full-page rectangle inserted at the
+ * bottom of the schema stack (so subsequent fields render on top).
+ *
+ * Backgrounds live as a regular pdfme `rectangle` schema field rather
+ * than a custom basePdf — that way they're editable, swappable, and
+ * removable without re-uploading a PDF, and they survive a template
+ * save/load round-trip via the same schemas jsonb column.
+ */
+export type Background = {
+    id: string;
+    name: string;
+    color: string;
+};
+
+export const BACKGROUNDS: Background[] = [
+    { id: 'white',     name: 'Hvit',         color: '#ffffff' },
+    { id: 'cream',     name: 'Krem',         color: '#fbf7ee' },
+    { id: 'mint',      name: 'Mynte',        color: '#eaf5ee' },
+    { id: 'blue',      name: 'Lyseblå',      color: '#eaf2fb' },
+    { id: 'blush',     name: 'Rosa',         color: '#fbecec' },
+    { id: 'lavender',  name: 'Lavendel',     color: '#f1ecfb' },
+    { id: 'sand',      name: 'Sand',         color: '#f5efe1' },
+    { id: 'graphite',  name: 'Grafitt',      color: '#1f2937' },
+];
+
+function makeBackgroundField(color: string): Schema {
+    return {
+        name: BG_FIELD_NAME,
+        type: 'rectangle',
+        position: { x: 0, y: 0 },
+        width: 210,
+        height: 297,
+        color,
+        borderColor: '',
+        borderWidth: 0,
+        rotate: 0,
+        readOnly: true,
+    } as Schema;
+}
+
+/**
+ * Replace (or insert) the background rectangle on page 0 of the template.
+ * The background field always sits at index 0 so other fields render
+ * above it. Idempotent: re-applying with the same color is a no-op.
+ */
+export function applyBackground(template: Template, color: string | null): Template {
+    const pages = template.schemas ?? [[]];
+    const firstPage = pages[0] ?? [];
+
+    const withoutBg = firstPage.filter((f) => f?.name !== BG_FIELD_NAME);
+
+    const nextFirst: Schema[] = color
+        ? [makeBackgroundField(color), ...withoutBg]
+        : withoutBg;
+
+    const nextSchemas = [nextFirst, ...pages.slice(1)];
+    return { ...template, schemas: nextSchemas };
+}
+
+/**
+ * Read the current background color from the template's schemas, or
+ * null if no background field is set.
+ */
+export function readBackgroundColor(template: Template): string | null {
+    const firstPage = template.schemas?.[0] ?? [];
+    const bg = firstPage.find((f) => f?.name === BG_FIELD_NAME);
+    if (!bg) return null;
+    const color = (bg as { color?: unknown }).color;
+    return typeof color === 'string' ? color : null;
+}


### PR DESCRIPTION
## Summary

Five small, focused improvements to the template-creation flow, on top of #14. The theme is **let admins ship a usable cert PDF with fewer manual steps**, leveraging org_assets defaults so the designer's outputs are wired up the moment a field hits the canvas.

## Commits

| # | Commit | What & why |
|---|---|---|
| 1 | Background picker | Swatch row in the designer — pick a page color (Krem / Mynte / Lyseblå / …) without uploading a PDF. Implemented as a full-page rectangle at index 0 of the schemas array so it's editable, swappable, and lives in the same jsonb column as everything else. |
| 2 | Auto-bind system slots | `qr_code` / `qr_info` / `qr_page` / `today` / `signature_date` fields auto-wire themselves to the matching system slot on save. Manual configuration always wins — only fills gaps. One fewer bindings-editor visit for the most common case. |
| 3 | Slugify label → key | Type "Mottakers navn" as the label, key auto-fills as `mottakers_navn` (ASCII, underscores, Norwegian accents folded). Sticky-edit: hand-editing the key flips `autoKey: false` so subsequent label edits don't clobber. Field labels also come before keys in the row now. |
| 4 | Quick-add toolbar | "+ QR-kode" / "+ Signatur" / "+ Logo" / "+ Tekstblokk" / "+ attester.no-merke" buttons. Each drops a pre-wired field (or 3-field block for signature) bound to the org's default asset at the next free position. Cascades on repeated clicks so a dual-signature row is two clicks instead of six. |
| 5 | Designer polish | Live "Klar til lagring" chip with specific reason if not; beforeunload guard on unsaved changes (loads + saves don't trigger); up/down reorder arrows in SchemaEditor; missing-defaults hint under the quick-add row pointing to Innhold if no default signature/logo/body_text is set up. |

## Test plan

- [ ] Background picker: click each swatch, confirm page color updates in the designer. Save + reload — color persists.
- [ ] Auto-bind: drop a fresh `qr_code` field via pdfme's left panel (no manual binding), save, reopen — the binding shows `system: qr_code`.
- [ ] Slugify: in SchemaEditor, add a new field, type "Født år" in label → key becomes `fodt_ar`. Hand-edit the key → subsequent label edits no longer overwrite.
- [ ] Quick-add: empty designer → click "+ QR-kode" then "+ Signatur" twice → see QR + 2-signature row, all bound. Click "+ Signatur" again with no default signature → field appears, hint mentions Innhold link.
- [ ] Live chip: with neither QR nor "attester.no" → orange `Mangler QR-kode · Mangler attester.no-tekst`. Add QR → chip updates to just `Mangler attester.no-tekst`. Add brand → green ✓.
- [ ] Reorder: SchemaEditor with 3+ fields → up/down arrows reorder, disabled at edges.
- [ ] beforeunload: edit a field, try to navigate away → browser confirm prompt. Save → no prompt.

## Out of scope (still queued)

Visual binding badge per pdfme field, asset thumbnails in BindingsEditor, inline lookup-list add, starter gallery preview cards, drag-to-reorder (we shipped up/down arrows instead).

---
_Generated by [Claude Code](https://claude.ai/code/session_0142AspkipemJMg1ggSqfQzg)_