### PR TITLE
Phase 3: org & member onboarding

### DIFF
--- a/scripts/create-org.ts
+++ b/scripts/create-org.ts
@@ -1,0 +1,104 @@
+/**
+ * Creates a new organization and links its first admin member.
+ * Assisted onboarding until a super-admin UI exists — everything after
+ * this (templates, assets, form) is self-serve in the app.
+ *
+ * The admin must already have a user account (create it in the Nhost
+ * dashboard under Auth → Users, or have them sign in once via an
+ * invite flow when one exists).
+ *
+ * Run from the repo root:
+ *   npx tsx --env-file=.env.local scripts/create-org.ts <slug> "<Org name>" <admin-email>
+ *
+ * Example:
+ *   npx tsx --env-file=.env.local scripts/create-org.ts kjelleren "Kjelleren Studentkro" styret@kjelleren.no
+ */
+
+export {}; // module scope — keeps top-level names from colliding with the other scripts
+
+const SUBDOMAIN = process.env.NEXT_PUBLIC_NHOST_SUBDOMAIN;
+const REGION = process.env.NEXT_PUBLIC_NHOST_REGION;
+const ADMIN_SECRET = process.env.NHOST_ADMIN_SECRET;
+
+if (!SUBDOMAIN || !REGION || !ADMIN_SECRET) {
+    console.error("Missing env vars: NEXT_PUBLIC_NHOST_SUBDOMAIN, NEXT_PUBLIC_NHOST_REGION, NHOST_ADMIN_SECRET");
+    process.exit(1);
+}
+
+const HASURA = `https://${SUBDOMAIN}.hasura.${REGION}.nhost.run/v1/graphql`;
+
+async function gql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    const res = await fetch(HASURA, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-hasura-admin-secret": ADMIN_SECRET! },
+        body: JSON.stringify({ query, variables }),
+    });
+    const json = await res.json() as { data?: T; errors?: { message: string }[] };
+    if (json.errors?.length) throw new Error(json.errors[0].message);
+    return json.data as T;
+}
+
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+async function main() {
+    const [slug, name, adminEmail] = process.argv.slice(2);
+    if (!slug || !name || !adminEmail) {
+        console.error('Usage: npx tsx --env-file=.env.local scripts/create-org.ts <slug> "<Org name>" <admin-email>');
+        process.exit(1);
+    }
+    if (!SLUG_RE.test(slug)) {
+        console.error(`Invalid slug "${slug}" — lowercase letters, digits and hyphens only.`);
+        process.exit(1);
+    }
+
+    const existing = await gql<{ organizations: { id: string }[] }>(
+        `query OrgExists($slug: String!) {
+            organizations(where: { slug: { _eq: $slug } }, limit: 1) { id }
+        }`,
+        { slug },
+    );
+    if (existing.organizations.length > 0) {
+        console.error(`Org "${slug}" already exists (${existing.organizations[0].id}).`);
+        process.exit(1);
+    }
+
+    const userData = await gql<{ users: { id: string; email: string }[] }>(
+        `query GetUser($email: citext!) {
+            users(where: { email: { _eq: $email } }, limit: 1) { id email }
+        }`,
+        { email: adminEmail.toLowerCase() },
+    );
+    const user = userData.users[0];
+    if (!user) {
+        console.error(`No user account for "${adminEmail}". Create it in the Nhost dashboard (Auth → Users) first.`);
+        process.exit(1);
+    }
+
+    const created = await gql<{ insert_organizations_one: { id: string } }>(
+        `mutation CreateOrg($slug: String!, $name: String!) {
+            insert_organizations_one(object: { slug: $slug, name: $name }) { id }
+        }`,
+        { slug, name },
+    );
+    await gql(
+        `mutation AddMember($userId: uuid!, $organizationId: uuid!) {
+            insert_user_organizations_one(object: {
+                user_id: $userId,
+                organization_id: $organizationId
+            }) { user_id }
+        }`,
+        { userId: user.id, organizationId: created.insert_organizations_one.id },
+    );
+
+    console.log(`Created org "${name}" (${created.insert_organizations_one.id})`);
+    console.log(`  slug:   ${slug}`);
+    console.log(`  admin:  ${user.email}`);
+    console.log("");
+    console.log("Next steps for the org admin:");
+    console.log(`  1. Log in at /login and open the org.`);
+    console.log(`  2. Create a PDF template ("PDF-mal" → starter gallery).`);
+    console.log(`  3. Add signatures/logos under "Innhold".`);
+    console.log(`  4. Share the public form: /org/${slug}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -12,6 +12,8 @@
  * re-tracked" is the most common failure mode and it can ONLY be caught
  * at the GraphQL layer.
  */
+export {}; // module scope — keeps top-level names from colliding with the other scripts
+
 const SUBDOMAIN = process.env.NEXT_PUBLIC_NHOST_SUBDOMAIN;
 const REGION = process.env.NEXT_PUBLIC_NHOST_REGION;
 const ADMIN_SECRET = process.env.NHOST_ADMIN_SECRET;

--- a/src/app/api/org/[slug]/members/route.ts
+++ b/src/app/api/org/[slug]/members/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { hasuraAdmin } from "@/lib/server/hasura";
+import { requireOrgMemberBySlug } from "@/lib/server/apiAuth";
+import { getUserByEmail, getUsersByIds } from "@/lib/server/authUsers";
+
+export const runtime = "edge";
+
+type MembershipRow = { user_id: string; role: string };
+
+async function listMemberships(organizationId: string): Promise<MembershipRow[]> {
+    const data = await hasuraAdmin<{ user_organizations: MembershipRow[] }>(
+        `query GetMembers($organizationId: uuid!) {
+            user_organizations(where: { organization_id: { _eq: $organizationId } }) {
+                user_id role
+            }
+        }`,
+        { organizationId },
+    );
+    return data.user_organizations;
+}
+
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    const auth = await requireOrgMemberBySlug(req, slug);
+    if (auth instanceof NextResponse) return auth;
+
+    try {
+        const memberships = await listMemberships(auth.organizationId);
+        const users = await getUsersByIds(memberships.map((m) => m.user_id));
+        const byId = new Map(users.map((u) => [u.id, u]));
+        const members = memberships.map((m) => ({
+            userId: m.user_id,
+            role: m.role,
+            email: byId.get(m.user_id)?.email ?? null,
+            displayName: byId.get(m.user_id)?.displayName ?? null,
+            isSelf: m.user_id === auth.userId,
+        }));
+        return NextResponse.json({ members });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}
+
+export async function POST(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    const auth = await requireOrgMemberBySlug(req, slug);
+    if (auth instanceof NextResponse) return auth;
+
+    const { email } = await req.json().catch(() => ({} as { email?: unknown }));
+    if (typeof email !== "string" || !email.includes("@")) {
+        return NextResponse.json({ error: "Ugyldig e-postadresse" }, { status: 400 });
+    }
+
+    try {
+        const user = await getUserByEmail(email.trim().toLowerCase());
+        if (!user) {
+            return NextResponse.json(
+                { error: "Fant ingen bruker med denne e-posten. Brukeren må ha en konto i systemet først." },
+                { status: 404 },
+            );
+        }
+
+        const existing = await listMemberships(auth.organizationId);
+        if (existing.some((m) => m.user_id === user.id)) {
+            return NextResponse.json({ error: "Brukeren er allerede medlem" }, { status: 409 });
+        }
+
+        await hasuraAdmin(
+            `mutation AddMember($userId: uuid!, $organizationId: uuid!) {
+                insert_user_organizations_one(object: {
+                    user_id: $userId,
+                    organization_id: $organizationId
+                }) { user_id }
+            }`,
+            { userId: user.id, organizationId: auth.organizationId },
+        );
+        return NextResponse.json({
+            member: { userId: user.id, email: user.email, displayName: user.displayName, role: "admin", isSelf: false },
+        });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    const auth = await requireOrgMemberBySlug(req, slug);
+    if (auth instanceof NextResponse) return auth;
+
+    const { userId } = await req.json().catch(() => ({} as { userId?: unknown }));
+    if (typeof userId !== "string" || !userId) {
+        return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    }
+
+    try {
+        // Lockout guard: an org must always keep at least one member —
+        // there is no super-admin UI to re-add one.
+        const memberships = await listMemberships(auth.organizationId);
+        if (!memberships.some((m) => m.user_id === userId)) {
+            return NextResponse.json({ error: "Brukeren er ikke medlem" }, { status: 404 });
+        }
+        if (memberships.length <= 1) {
+            return NextResponse.json(
+                { error: "Kan ikke fjerne det siste medlemmet i organisasjonen" },
+                { status: 400 },
+            );
+        }
+
+        await hasuraAdmin(
+            `mutation RemoveMember($userId: uuid!, $organizationId: uuid!) {
+                delete_user_organizations(where: {
+                    user_id: { _eq: $userId },
+                    organization_id: { _eq: $organizationId }
+                }) { affected_rows }
+            }`,
+            { userId, organizationId: auth.organizationId },
+        );
+        return NextResponse.json({ ok: true });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}

--- a/src/app/login/adminpage/[orgSlug]/layout.tsx
+++ b/src/app/login/adminpage/[orgSlug]/layout.tsx
@@ -68,6 +68,14 @@ export default function OrgAdminLayout({ children }: { children: React.ReactNode
                     </Button>
                     <Button
                         component={Link}
+                        href={`/login/adminpage/${orgSlug}/medlemmer`}
+                        variant="outlined"
+                        size="small"
+                    >
+                        Medlemmer
+                    </Button>
+                    <Button
+                        component={Link}
                         href={`/org/${orgSlug}`}
                         target="_blank"
                         rel="noreferrer"

--- a/src/app/login/adminpage/[orgSlug]/medlemmer/page.tsx
+++ b/src/app/login/adminpage/[orgSlug]/medlemmer/page.tsx
@@ -1,0 +1,170 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+    Box, Button, CircularProgress, IconButton, List, ListItem, ListItemText,
+    Paper, TextField, Typography,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { authHeader } from '@/lib/nhost';
+import { useToast } from '@/components/ToastProvider';
+import ConfirmDialog from '@/util/confirmDialog';
+
+type Member = {
+    userId: string;
+    role: string;
+    email: string | null;
+    displayName: string | null;
+    isSelf: boolean;
+};
+
+const MembersPage: React.FC = () => {
+    const { orgSlug } = useParams<{ orgSlug: string }>();
+    const toast = useToast();
+    const [members, setMembers] = useState<Member[] | null>(null);
+    const [newEmail, setNewEmail] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [toRemove, setToRemove] = useState<Member | null>(null);
+
+    const load = useCallback(async () => {
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/members`, {
+                headers: authHeader(),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            setMembers(json.members);
+        } catch (e) {
+            toast.error(`Kunne ikke laste medlemmer: ${(e as Error).message}`);
+            setMembers([]);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [orgSlug]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const handleAdd = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (busy || !newEmail) return;
+        setBusy(true);
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/members`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...authHeader() },
+                body: JSON.stringify({ email: newEmail }),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            setNewEmail('');
+            toast.success('Medlem lagt til');
+            await load();
+        } catch (err) {
+            toast.error((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRemove = async () => {
+        if (!toRemove) return;
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/members`, {
+                method: 'DELETE',
+                headers: { 'content-type': 'application/json', ...authHeader() },
+                body: JSON.stringify({ userId: toRemove.userId }),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            toast.success('Medlemmet er fjernet');
+            setToRemove(null);
+            await load();
+        } catch (err) {
+            toast.error((err as Error).message);
+            setToRemove(null);
+        }
+    };
+
+    return (
+        <>
+            <Typography variant="h4" gutterBottom>Medlemmer</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Alle medlemmer kan godkjenne innsendinger, utstede attester og
+                redigere maler og innhold for organisasjonen.
+            </Typography>
+
+            <Paper sx={{ p: 3, mb: 3 }}>
+                <Typography variant="h6" gutterBottom>Legg til medlem</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Personen må allerede ha en brukerkonto. Skriv inn e-postadressen
+                    kontoen er registrert med.
+                </Typography>
+                <Box component="form" onSubmit={handleAdd} sx={{ display: 'flex', gap: 2 }}>
+                    <TextField
+                        size="small"
+                        type="email"
+                        label="E-post"
+                        value={newEmail}
+                        onChange={(e) => setNewEmail(e.target.value)}
+                        disabled={busy}
+                        sx={{ flex: 1, maxWidth: 400 }}
+                    />
+                    <Button type="submit" variant="contained" disabled={busy || !newEmail}>
+                        {busy ? <CircularProgress size={20} /> : 'Legg til'}
+                    </Button>
+                </Box>
+            </Paper>
+
+            <Paper sx={{ p: 3 }}>
+                <Typography variant="h6" gutterBottom>Nåværende medlemmer</Typography>
+                {members === null ? (
+                    <CircularProgress size={24} />
+                ) : members.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">Ingen medlemmer funnet.</Typography>
+                ) : (
+                    <List>
+                        {members.map((m) => (
+                            <ListItem
+                                key={m.userId}
+                                secondaryAction={
+                                    <IconButton
+                                        edge="end"
+                                        aria-label="Fjern medlem"
+                                        onClick={() => setToRemove(m)}
+                                        disabled={members.length <= 1}
+                                    >
+                                        <DeleteIcon />
+                                    </IconButton>
+                                }
+                            >
+                                <ListItemText
+                                    primary={
+                                        (m.displayName || m.email || m.userId)
+                                        + (m.isSelf ? ' (deg)' : '')
+                                    }
+                                    secondary={m.displayName ? m.email : null}
+                                />
+                            </ListItem>
+                        ))}
+                    </List>
+                )}
+            </Paper>
+
+            <ConfirmDialog
+                open={toRemove !== null}
+                title="Fjern medlem"
+                message={
+                    toRemove?.isSelf
+                        ? 'Du er i ferd med å fjerne deg selv fra organisasjonen. Du mister tilgangen umiddelbart. Er du sikker?'
+                        : `Vil du fjerne ${toRemove?.displayName || toRemove?.email || 'medlemmet'} fra organisasjonen?`
+                }
+                onConfirm={handleRemove}
+                onClose={() => setToRemove(null)}
+                confirmButtonText="Fjern"
+            />
+        </>
+    );
+};
+
+export default MembersPage;

--- a/src/app/login/glemt/page.tsx
+++ b/src/app/login/glemt/page.tsx
@@ -1,0 +1,74 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { Box, Button, CircularProgress, Container, TextField, Typography } from '@mui/material';
+import { requestPasswordReset } from '@/util/auth';
+import { useToast } from '@/components/ToastProvider';
+
+const ForgotPasswordPage: React.FC = () => {
+    const [email, setEmail] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [sent, setSent] = useState(false);
+    const toast = useToast();
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (busy) return;
+        setBusy(true);
+        try {
+            await requestPasswordReset(email);
+            setSent(true);
+        } catch (error) {
+            console.error(error);
+            toast.error((error as Error).message ?? 'Noe gikk galt');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Container component="main" maxWidth="xs">
+            <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography component="h1" variant="h5" gutterBottom>
+                    Glemt passord
+                </Typography>
+                {sent ? (
+                    <Typography variant="body1" sx={{ mt: 2 }}>
+                        Hvis kontoen finnes, er det sendt en e-post med lenke for å
+                        sette nytt passord. Sjekk innboksen din.
+                    </Typography>
+                ) : (
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1, width: '100%' }}>
+                        <TextField
+                            variant="outlined"
+                            margin="normal"
+                            required
+                            fullWidth
+                            label="E-post"
+                            type="email"
+                            autoComplete="email"
+                            autoFocus
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            disabled={busy}
+                        />
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 3, mb: 2 }}
+                            disabled={busy || !email}
+                        >
+                            {busy ? <CircularProgress size={20} /> : 'Send lenke'}
+                        </Button>
+                    </Box>
+                )}
+                <Link href="/login">Tilbake til innlogging</Link>
+            </Box>
+        </Container>
+    );
+};
+
+export default ForgotPasswordPage;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { login, useAuth } from '@/util/auth';
 import { Box, Button, CircularProgress, Container, TextField, Typography } from '@mui/material';
 import { useRouter } from 'next/navigation';
@@ -82,6 +83,9 @@ const LoginPage: React.FC = () => {
                     >
                         {busy ? <CircularProgress size={20} /> : 'Logg Inn'}
                     </Button>
+                    <Link href="/login/glemt" style={{ fontSize: '0.875rem' }}>
+                        Glemt passord?
+                    </Link>
                 </Box>
             </Box>
         </Container>

--- a/src/app/login/reset/page.tsx
+++ b/src/app/login/reset/page.tsx
@@ -1,0 +1,103 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Box, Button, CircularProgress, Container, TextField, Typography } from '@mui/material';
+import { completePasswordReset } from '@/util/auth';
+import { useToast } from '@/components/ToastProvider';
+
+const ResetPasswordPage: React.FC = () => {
+    const searchParams = useSearchParams();
+    const refreshToken = searchParams.get('refreshToken');
+    const [password, setPassword] = useState('');
+    const [confirm, setConfirm] = useState('');
+    const [busy, setBusy] = useState(false);
+    const router = useRouter();
+    const toast = useToast();
+
+    if (!refreshToken) {
+        return (
+            <Container component="main" maxWidth="xs">
+                <Box sx={{ mt: 8, textAlign: 'center' }}>
+                    <Typography variant="h5" gutterBottom>Ugyldig lenke</Typography>
+                    <Typography variant="body1" sx={{ mb: 2 }}>
+                        Lenken mangler eller er utløpt. Be om en ny.
+                    </Typography>
+                    <Link href="/login/glemt">Glemt passord</Link>
+                </Box>
+            </Container>
+        );
+    }
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (busy) return;
+        if (password !== confirm) {
+            toast.error('Passordene er ikke like');
+            return;
+        }
+        setBusy(true);
+        try {
+            await completePasswordReset(refreshToken, password);
+            toast.success('Passordet er endret. Logg inn med det nye passordet.');
+            router.push('/login');
+        } catch (error) {
+            console.error(error);
+            toast.error(
+                ((error as Error).message ?? 'Noe gikk galt')
+                + '. Lenken kan være utløpt – be om en ny under «Glemt passord».',
+            );
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Container component="main" maxWidth="xs">
+            <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography component="h1" variant="h5">
+                    Sett nytt passord
+                </Typography>
+                <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1, width: '100%' }}>
+                    <TextField
+                        variant="outlined"
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="Nytt passord"
+                        type="password"
+                        autoComplete="new-password"
+                        autoFocus
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        disabled={busy}
+                    />
+                    <TextField
+                        variant="outlined"
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="Gjenta nytt passord"
+                        type="password"
+                        autoComplete="new-password"
+                        value={confirm}
+                        onChange={(e) => setConfirm(e.target.value)}
+                        disabled={busy}
+                    />
+                    <Button
+                        type="submit"
+                        fullWidth
+                        variant="contained"
+                        sx={{ mt: 3, mb: 2 }}
+                        disabled={busy || !password || !confirm}
+                    >
+                        {busy ? <CircularProgress size={20} /> : 'Endre passord'}
+                    </Button>
+                </Box>
+            </Box>
+        </Container>
+    );
+};
+
+export default ResetPasswordPage;

--- a/src/lib/server/authUsers.ts
+++ b/src/lib/server/authUsers.ts
@@ -1,0 +1,32 @@
+import { hasuraAdmin } from "@/lib/server/hasura";
+
+// Nhost tracks auth.users in Hasura under the root field `users`. We only
+// ever read id/email/displayName — never write. User accounts themselves
+// are managed by Nhost Auth.
+
+export type AuthUser = { id: string; email: string; displayName: string | null };
+
+export async function getUserByEmail(email: string): Promise<AuthUser | null> {
+    const data = await hasuraAdmin<{ users: AuthUser[] }>(
+        `query GetUserByEmail($email: citext!) {
+            users(where: { email: { _eq: $email } }, limit: 1) {
+                id email displayName
+            }
+        }`,
+        { email },
+    );
+    return data.users[0] ?? null;
+}
+
+export async function getUsersByIds(ids: string[]): Promise<AuthUser[]> {
+    if (ids.length === 0) return [];
+    const data = await hasuraAdmin<{ users: AuthUser[] }>(
+        `query GetUsersByIds($ids: [uuid!]!) {
+            users(where: { id: { _in: $ids } }) {
+                id email displayName
+            }
+        }`,
+        { ids },
+    );
+    return data.users;
+}

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -10,6 +10,28 @@ export const logout = async (): Promise<void> => {
     await nhost.auth.signOut({ refreshToken: session?.refreshToken });
 };
 
+export const requestPasswordReset = async (email: string): Promise<void> => {
+    await nhost.auth.sendPasswordResetEmail({
+        email,
+        options: { redirectTo: `${window.location.origin}/login/reset` },
+    });
+};
+
+/**
+ * Completes the email reset flow: the link from Nhost redirects here with a
+ * refreshToken in the URL; exchanging it establishes a session, and the
+ * password change then revokes every session (including this one), so the
+ * user must sign in again with the new password.
+ */
+export const completePasswordReset = async (
+    refreshToken: string,
+    newPassword: string,
+): Promise<void> => {
+    await nhost.auth.refreshToken({ refreshToken });
+    await nhost.auth.changeUserPassword({ newPassword });
+    nhost.clearSession();
+};
+
 export const useAuth = (): NhostUser | null | undefined => {
     const [user, setUser] = useState<NhostUser | null | undefined>(undefined);
     useEffect(() => {


### PR DESCRIPTION
Stacked on #16 (base is `claude/page-market-readiness-x35fdx` so the diff shows only phase 3 — retarget to `main` after #16 merges).

Removes the biggest adoption blocker: org creation and member linking were raw SQL in the Hasura console, and the admin empty-state told users to "ask an admin to add you" with no such feature existing.

## Member management
- New **Medlemmer** tab in the org admin: list members (emails resolved from Nhost auth users), add by email, remove with a confirm dialog (extra warning when removing yourself).
- API `GET/POST/DELETE /api/org/[slug]/members`, guarded by the existing `requireOrgMemberBySlug`. A lockout guard refuses to remove the last member of an org.
- New `src/lib/server/authUsers.ts` reads (never writes) `auth.users` via the Hasura `users` root field.

## Password reset
- "Glemt passord?" on the login page → `/login/glemt` sends Nhost's reset email → the emailed link lands on `/login/reset`, which exchanges the `refreshToken` and sets the new password (Nhost revokes all sessions; the user signs in again).

## Assisted org creation
- `scripts/create-org.ts <slug> "<Name>" <admin-email>` creates the org row and links the first admin (who must already have an Nhost account). Everything after that — templates, assets, form — is self-serve in the app.

## Deploy notes (one-time, Nhost dashboard)
- Add the production URL + `/login/reset` to **Auth → Redirect URLs** (`ALLOWED_REDIRECT_URLS`) so the reset email may redirect there.
- The members API assumes `auth.users` is tracked in Hasura as `users` (Nhost default) and that `user_organizations` insert/delete root fields are tracked (its select already is).

## Verification
- Typecheck, lint, 99 tests, production build all pass.
- The reset + members flows need a manual end-to-end pass against the live Nhost project before merging — that's why this is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_