### PR TITLE
Phase 5: admin UX — PDF preview before issuing, copy verify-link, list filters

### DIFF
--- a/src/app/login/adminpage/[orgSlug]/page.tsx
+++ b/src/app/login/adminpage/[orgSlug]/page.tsx
@@ -5,9 +5,9 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { authHeader } from '@/lib/nhost';
 import {
-    Button, Checkbox, FormControlLabel, Grid, Link, Paper, Typography
+    Button, Checkbox, FormControlLabel, Grid, Link, MenuItem, Paper, TextField, Typography
 } from '@mui/material';
-import { generatePDF, TemplateData } from '@/app/login/adminpage/generatePDF';
+import { generatePDF, previewPDF, TemplateData } from '@/app/login/adminpage/generatePDF';
 import { deleteSubmission } from "@/util/deleteSubmission";
 import ConfirmDialog from "@/util/confirmDialog";
 import { generateURL } from "@/app/login/adminpage/generateURL";
@@ -45,6 +45,10 @@ const AdminPage: React.FC = () => {
     const [openBatchDeleteDialog, setOpenBatchDeleteDialog] = useState(false);
     const [openPDFDialog, setOpenPDFDialog] = useState(false);
     const [pdfUrl, setPdfUrl] = useState('');
+
+    const [searchText, setSearchText] = useState('');
+    const [templateFilter, setTemplateFilter] = useState('');
+    const [newestFirst, setNewestFirst] = useState(true);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -180,6 +184,15 @@ const AdminPage: React.FC = () => {
     const selectedTemplate = selected ? templateById(selected.templateId) : null;
     const selectedSchema = selectedTemplate?.form_schema ?? null;
 
+    const query = searchText.trim().toLowerCase();
+    const visibleSubmissions = submissions
+        .filter((s) => !templateFilter || s.templateId === templateFilter)
+        .filter((s) => !query
+            || Object.values(s.data).some((v) => v.toLowerCase().includes(query)))
+        .sort((a, b) => newestFirst
+            ? b.createdAt.getTime() - a.createdAt.getTime()
+            : a.createdAt.getTime() - b.createdAt.getTime());
+
     return (
         <>
             <Grid container alignItems="center" spacing={2} sx={{ mb: 2 }}>
@@ -192,6 +205,47 @@ const AdminPage: React.FC = () => {
                     </Button>
                 </Grid>
             </Grid>
+
+            {submissions.length > 0 && (
+                <Grid container spacing={2} alignItems="center" sx={{ mb: 1 }}>
+                    <Grid size={{ xs: 12, sm: 5 }}>
+                        <TextField
+                            fullWidth
+                            size="small"
+                            label="Søk i innsendinger"
+                            value={searchText}
+                            onChange={(e) => setSearchText(e.target.value)}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                        <TextField
+                            fullWidth
+                            select
+                            size="small"
+                            label="Mal"
+                            value={templateFilter}
+                            onChange={(e) => setTemplateFilter(e.target.value)}
+                        >
+                            <MenuItem value="">Alle maler</MenuItem>
+                            {templates.map((t) => (
+                                <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>
+                            ))}
+                        </TextField>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 3 }}>
+                        <Button size="small" onClick={() => setNewestFirst((v) => !v)}>
+                            {newestFirst ? 'Nyeste først ↓' : 'Eldste først ↑'}
+                        </Button>
+                    </Grid>
+                    {visibleSubmissions.length !== submissions.length && (
+                        <Grid size={{ xs: 12 }}>
+                            <Typography variant="caption" color="text.secondary">
+                                Viser {visibleSubmissions.length} av {submissions.length} innsendinger
+                            </Typography>
+                        </Grid>
+                    )}
+                </Grid>
+            )}
 
             {submissions.length === 0 && (
                 <Paper elevation={1} sx={{ p: 3, mb: 2, bgcolor: 'grey.50' }}>
@@ -211,7 +265,7 @@ const AdminPage: React.FC = () => {
             )}
 
             <Grid container spacing={2}>
-                {submissions.map((sub) => {
+                {visibleSubmissions.map((sub) => {
                     const tmpl = templateById(sub.templateId);
                     const schema = tmpl?.form_schema ?? null;
                     return (
@@ -265,13 +319,28 @@ const AdminPage: React.FC = () => {
             <ConfirmDialog
                 open={openDialog}
                 title="Bekreft generering av PDF"
-                message="Er du sikker på at du vil generere PDF?"
+                message="Når du genererer PDF-en, registreres attesten og innsendingen slettes automatisk. Bruk forhåndsvisningen hvis du vil se resultatet først."
                 details={selected && selectedSchema ? (
                     <SchemaDetails schema={selectedSchema} data={selected.data} />
                 ) : null}
                 onConfirm={handleConfirm}
                 onClose={handleClose}
                 confirmButtonText="Generer PDF"
+                secondaryAction={
+                    selected && selectedTemplate
+                        ? {
+                              label: 'Forhåndsvis',
+                              onClick: async () => {
+                                  try {
+                                      await previewPDF(orgSlug, selectedTemplate, selected.id, selected.data);
+                                  } catch (e) {
+                                      console.error(e);
+                                      toast.error('Feil ved forhåndsvisning: ' + ((e as Error).message ?? 'ukjent feil'));
+                                  }
+                              },
+                          }
+                        : undefined
+                }
             />
 
             <ConfirmDialog
@@ -304,6 +373,17 @@ const AdminPage: React.FC = () => {
                 onClose={() => { setOpenPDFDialog(false); setSelected(null); }}
                 confirmButtonText="Lukk"
                 showCancelButton={false}
+                secondaryAction={{
+                    label: 'Kopier lenke',
+                    onClick: async () => {
+                        try {
+                            await navigator.clipboard.writeText(pdfUrl);
+                            toast.success('Verifiseringslenken er kopiert');
+                        } catch {
+                            toast.error('Kunne ikke kopiere – marker lenken manuelt');
+                        }
+                    },
+                }}
             />
         </>
     );

--- a/src/app/login/adminpage/generatePDF.ts
+++ b/src/app/login/adminpage/generatePDF.ts
@@ -1,6 +1,7 @@
 import { barcodes, image, text } from '@pdfme/schemas';
 import { generate } from '@pdfme/generator';
 import { Template } from '@pdfme/common';
+import type { Schema } from '@pdfme/common';
 import { getPdfInput } from '@/app/login/adminpage/getPDFInput';
 import { decorateTemplateForGenerate } from '@/util/decorateTemplate';
 import type { FieldBindings } from '@/types/fieldBindings';
@@ -40,6 +41,72 @@ export const generatePDF = async (
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
     link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+// Diagonal grey banner stamped on every page of a preview render, so a
+// preview that escapes into the world can't pass as an issued attest.
+// Mirrors the full field shape used by decorateTemplate's verify label —
+// pdfme skips or clips fields with a sparser shape.
+const previewWatermark = (pageIndex: number): Schema => ({
+    name: `__preview_watermark__${pageIndex}`,
+    type: 'text',
+    content: 'FORHÅNDSVISNING – IKKE GYLDIG ATTEST',
+    position: { x: 10, y: 130 },
+    width: 190,
+    height: 20,
+    rotate: 30,
+    alignment: 'center',
+    verticalAlignment: 'middle',
+    fontSize: 24,
+    lineHeight: 1,
+    characterSpacing: 1,
+    fontColor: '#b9b9b9',
+    backgroundColor: '',
+    opacity: 0.7,
+    required: false,
+} as Schema);
+
+/**
+ * Render the attest exactly as generatePDF would — same bindings, same real
+ * submission data, same QR URL — but WITHOUT touching the certificates
+ * route: no hash is registered and the submission is not deleted. Opens in
+ * a new tab with a watermark instead of downloading.
+ */
+export const previewPDF = async (
+    orgSlug: string,
+    templateData: TemplateData,
+    submissionId: string,
+    data: Record<string, string>,
+) => {
+    const pdfInput = await getPdfInput(
+        orgSlug,
+        templateData.id,
+        submissionId,
+        data,
+        templateData.schemas,
+        templateData.field_bindings,
+    );
+    const decorated = decorateTemplateForGenerate({
+        basePdf: templateData.base_pdf,
+        schemas: templateData.schemas,
+    });
+    const template: Template = {
+        ...decorated,
+        schemas: (decorated.schemas ?? []).map((page, i) => [...(page ?? []), previewWatermark(i)]),
+    };
+    const pdf = await generate({
+        template,
+        inputs: pdfInput,
+        plugins: { text, image, qrcode: barcodes.qrcode },
+    });
+    const blob = new Blob([new Uint8Array(pdf.buffer)], { type: 'application/pdf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.target = '_blank';
+    link.rel = 'noreferrer';
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);


### PR DESCRIPTION
Stacked on #18 (base is `claude/phase-4-ops-polish` so the diff shows only phase 5). Merge order: #16 → #18 → this, retargeting bases as each lands.

## PDF preview before issuing
- **Forhåndsvis** button on the confirm dialog renders the attest from the real submission data through the exact `generatePDF` pipeline — same bindings, same QR URL — but **without** calling the certificates route: no hash registered, nothing deleted, opens in a new tab.
- Every page of a preview gets a diagonal "FORHÅNDSVISNING – IKKE GYLDIG ATTEST" watermark so a preview can never circulate as an issued attest.
- This matters more since #16: issuing now deletes the submission, so "generate and see" is no longer a safe way to check the result. The confirm-dialog copy now says so explicitly.

## Small workflow wins
- **Kopier lenke** on the post-issue dialog copies the verify URL to the clipboard.
- Submissions list: free-text search across field values, template dropdown filter, newest/oldest toggle, and a "viser X av Y" count. All client-side — the list is already fully loaded.

## Verification
- Typecheck, lint, 101 tests, production build pass.
- Preview needs one manual check against live data: open Forhåndsvis on a real submission and confirm the watermark renders and no certificate row appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_