### PR TITLE
Phase 6: public UX — form validation, confirmation screen, verify states, self-signup

### DIFF
--- a/src/app/login/adminpage/[orgSlug]/medlemmer/page.tsx
+++ b/src/app/login/adminpage/[orgSlug]/medlemmer/page.tsx
@@ -97,7 +97,8 @@ const MembersPage: React.FC = () => {
             <Paper sx={{ p: 3, mb: 3 }}>
                 <Typography variant="h6" gutterBottom>Legg til medlem</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                    Personen må allerede ha en brukerkonto. Skriv inn e-postadressen
+                    Personen må ha en brukerkonto — nye brukere kan opprette en
+                    selv på attester.no/registrer. Skriv inn e-postadressen
                     kontoen er registrert med.
                 </Typography>
                 <Box component="form" onSubmit={handleAdd} sx={{ display: 'flex', gap: 2 }}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -83,9 +83,14 @@ const LoginPage: React.FC = () => {
                     >
                         {busy ? <CircularProgress size={20} /> : 'Logg Inn'}
                     </Button>
-                    <Link href="/login/glemt" style={{ fontSize: '0.875rem' }}>
-                        Glemt passord?
-                    </Link>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <Link href="/login/glemt" style={{ fontSize: '0.875rem' }}>
+                            Glemt passord?
+                        </Link>
+                        <Link href="/registrer" style={{ fontSize: '0.875rem' }}>
+                            Registrer ny konto
+                        </Link>
+                    </Box>
                 </Box>
             </Box>
         </Container>

--- a/src/app/org/[orgSlug]/verify/OrgVerifyClient.tsx
+++ b/src/app/org/[orgSlug]/verify/OrgVerifyClient.tsx
@@ -73,20 +73,41 @@ const OrgVerifyClient: React.FC = () => {
               .map((k) => ({ key: k, label: k, type: 'text' as const }));
 
     return (
-        <Box sx={{ border: `5px solid ${getColor()}`, padding: 1, borderRadius: 2, margin: 2 }}>
-            <Typography variant="h3">Verifikasjon</Typography>
-            <Grid size={{ xs: 12, md: 6 }}>
-                <Typography variant="h6" color={getColor()}>
-                    {verificationResult === null
-                        ? 'Laster...'
-                        : verificationResult === 'verified'
-                            ? 'Attesten er gyldig!'
-                            : 'Attesten er ugyldig.'}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                    Endre feltene under for å verifisere mot lagret hash.
-                </Typography>
-            </Grid>
+        <Box sx={{ border: `5px solid ${getColor()}`, padding: 3, borderRadius: 2, margin: 2 }}>
+            <Typography variant="h3" gutterBottom>Verifikasjon</Typography>
+
+            {verificationResult === null ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, my: 2 }}>
+                    <CircularProgress size={28} />
+                    <Typography variant="h6" color="text.secondary">Kontrollerer attesten …</Typography>
+                </Box>
+            ) : verificationResult === 'verified' ? (
+                <Box sx={{ my: 2 }}>
+                    <Typography variant="h5" color={getColor()} sx={{ fontWeight: 700 }}>
+                        ✓ Attesten er gyldig
+                    </Typography>
+                    <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+                        Opplysningene under stemmer nøyaktig med attesten slik den ble
+                        utstedt. Endres så mye som ett tegn, blir den ugyldig.
+                    </Typography>
+                </Box>
+            ) : (
+                <Box sx={{ my: 2 }}>
+                    <Typography variant="h5" color={getColor()} sx={{ fontWeight: 700 }}>
+                        ✗ Attesten er ugyldig
+                    </Typography>
+                    <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+                        Opplysningene stemmer ikke med noen utstedt attest. Enten er
+                        lenken ufullstendig (skann QR-koden på nytt), et felt er endret,
+                        eller attesten er aldri utstedt av denne organisasjonen.
+                    </Typography>
+                </Box>
+            )}
+
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 3 }}>
+                Attesterte opplysninger — du kan endre et felt for å se at
+                verifiseringen da slår feil:
+            </Typography>
             <Grid container spacing={2} paddingTop={2}>
                 {schemaLoading ? (
                     <Grid size={{ xs: 12 }}>

--- a/src/app/orgSubmissionForm.tsx
+++ b/src/app/orgSubmissionForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react';
-import { Button, CircularProgress, Container, Grid, Typography } from '@mui/material';
+import { Button, CircularProgress, Container, Grid, Paper, Typography } from '@mui/material';
 import Link from "next/link";
 import { useSearchParams } from 'next/navigation';
 import { getOrgBySlug } from '@/lib/nhost';
@@ -22,8 +22,8 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
     const toast = useToast();
 
     const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
-    const [openSummaryDialog, setOpenSummaryDialog] = useState(false);
     const [openHelpDialog, setOpenHelpDialog] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
 
     const [orgName, setOrgName] = useState<string>(orgSlug);
     const [template, setTemplate] = useState<TemplateForForm | null>(null);
@@ -73,7 +73,8 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
             const json = await res.json();
             if (!res.ok) throw new Error(json.error ?? 'Server error');
             setOpenConfirmDialog(false);
-            setOpenSummaryDialog(true);
+            setSubmitted(true);
+            window.scrollTo({ top: 0 });
         } catch (e) {
             console.error('Error adding submission:', e);
             toast.error('Feil ved lagring av data: ' + ((e as Error).message ?? 'ukjent feil'));
@@ -96,6 +97,29 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
                     Ingen mal funnet for denne organisasjonen
                     {templateIdOverride ? ` (id ${templateIdOverride})` : ''}.
                 </Typography>
+            </Container>
+        );
+    }
+
+    if (submitted) {
+        return (
+            <Container component="main" maxWidth="sm">
+                <Paper elevation={2} sx={{ p: 4, mt: 6, textAlign: 'center' }}>
+                    <Typography variant="h2" component="div" aria-hidden sx={{ mb: 1 }}>✅</Typography>
+                    <Typography variant="h5" gutterBottom>Innsendingen er mottatt</Typography>
+                    <Typography variant="body1" color="text.secondary" sx={{ mb: 2, textAlign: 'left' }}>
+                        Dette skjer videre:
+                    </Typography>
+                    <Typography component="ol" variant="body2" color="text.secondary" sx={{ textAlign: 'left', pl: 3, mb: 3 }}>
+                        <li>{orgName} kontrollerer opplysningene dine.</li>
+                        <li>Godkjennes de, lages attesten som PDF med QR-kode, og du får den fra {orgName}.</li>
+                        <li>I samme øyeblikk slettes opplysningene dine fra databasen — bare en
+                            kryptografisk hash blir igjen, så attesten kan verifiseres.</li>
+                    </Typography>
+                    <Button variant="outlined" onClick={() => { setFormData({}); setSubmitted(false); }}>
+                        Send inn en ny
+                    </Button>
+                </Paper>
             </Container>
         );
     }
@@ -131,17 +155,6 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
                 onClose={() => setOpenConfirmDialog(false)}
                 details={<SchemaDetails schema={schema} data={formData} />}
                 confirmButtonText="Ja, lagre"
-            />
-
-            <ConfirmDialog
-                open={openSummaryDialog}
-                title="Innsending mottatt"
-                message="Denne informasjonen ble sendt inn:"
-                onConfirm={() => setOpenSummaryDialog(false)}
-                details={<SchemaDetails schema={schema} data={formData} />}
-                onClose={() => setOpenSummaryDialog(false)}
-                confirmButtonText="OK"
-                showCancelButton={false}
             />
 
             <ConfirmDialog

--- a/src/app/registrer/page.tsx
+++ b/src/app/registrer/page.tsx
@@ -1,0 +1,129 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Box, Button, CircularProgress, Container, TextField, Typography } from '@mui/material';
+import { signup } from '@/util/auth';
+import { useToast } from '@/components/ToastProvider';
+
+const RegisterPage: React.FC = () => {
+    const [displayName, setDisplayName] = useState('');
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [confirm, setConfirm] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [needsVerification, setNeedsVerification] = useState(false);
+    const router = useRouter();
+    const toast = useToast();
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (busy) return;
+        if (password !== confirm) {
+            toast.error('Passordene er ikke like');
+            return;
+        }
+        setBusy(true);
+        try {
+            const hasSession = await signup(email, password, displayName.trim());
+            if (hasSession) {
+                toast.success('Kontoen er opprettet');
+                router.push('/login/adminpage');
+            } else {
+                setNeedsVerification(true);
+            }
+        } catch (error) {
+            console.error(error);
+            toast.error((error as Error).message ?? 'Registrering feilet');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Container component="main" maxWidth="xs">
+            <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography component="h1" variant="h5" gutterBottom>
+                    Registrer konto
+                </Typography>
+                {needsVerification ? (
+                    <Typography variant="body1" sx={{ mt: 2 }}>
+                        Sjekk e-posten din og bekreft kontoen. Deretter kan du logge inn —
+                        og be et eksisterende medlem i organisasjonen din om å legge deg
+                        til under «Medlemmer».
+                    </Typography>
+                ) : (
+                    <>
+                        <Typography variant="body2" color="text.secondary" sx={{ mt: 1, mb: 1 }}>
+                            En konto gir ingen tilgang i seg selv — et eksisterende medlem
+                            må legge deg til i organisasjonen etterpå.
+                        </Typography>
+                        <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1, width: '100%' }}>
+                            <TextField
+                                variant="outlined"
+                                margin="normal"
+                                fullWidth
+                                label="Navn"
+                                autoComplete="name"
+                                autoFocus
+                                value={displayName}
+                                onChange={(e) => setDisplayName(e.target.value)}
+                                disabled={busy}
+                            />
+                            <TextField
+                                variant="outlined"
+                                margin="normal"
+                                required
+                                fullWidth
+                                label="E-post"
+                                type="email"
+                                autoComplete="email"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                disabled={busy}
+                            />
+                            <TextField
+                                variant="outlined"
+                                margin="normal"
+                                required
+                                fullWidth
+                                label="Passord"
+                                type="password"
+                                autoComplete="new-password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                disabled={busy}
+                            />
+                            <TextField
+                                variant="outlined"
+                                margin="normal"
+                                required
+                                fullWidth
+                                label="Gjenta passord"
+                                type="password"
+                                autoComplete="new-password"
+                                value={confirm}
+                                onChange={(e) => setConfirm(e.target.value)}
+                                disabled={busy}
+                            />
+                            <Button
+                                type="submit"
+                                fullWidth
+                                variant="contained"
+                                sx={{ mt: 3, mb: 2 }}
+                                disabled={busy || !email || !password || !confirm}
+                            >
+                                {busy ? <CircularProgress size={20} /> : 'Registrer'}
+                            </Button>
+                        </Box>
+                    </>
+                )}
+                <Link href="/login">Har du konto? Logg inn</Link>
+            </Box>
+        </Container>
+    );
+};
+
+export default RegisterPage;

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import {
     Button,
     FormControl,
+    FormHelperText,
     Grid,
     InputLabel,
     MenuItem,
@@ -10,6 +11,7 @@ import {
     TextField,
 } from '@mui/material';
 import type { FormSchema, FormFieldSchema } from '@/types/formSchema';
+import { validateField } from '@/util/validateFormField';
 
 interface Props {
     schema: FormSchema;
@@ -20,22 +22,45 @@ interface Props {
 
 const SchemaForm: React.FC<Props> = ({ schema, onSubmit, submitLabel = 'Send inn', initialData = {} }) => {
     const [data, setData] = useState<Record<string, string>>(initialData);
+    const [errors, setErrors] = useState<Record<string, string>>({});
 
     const handleChange = (key: string, value: string) => {
         setData((prev) => ({ ...prev, [key]: value }));
+        // Re-validate the touched field immediately so errors clear as the
+        // volunteer fixes them, instead of sticking until the next submit.
+        setErrors((prev) => {
+            if (!(key in prev)) return prev;
+            const field = schema.find((f) => f.key === key);
+            const err = field ? validateField(field, value) : null;
+            const next = { ...prev };
+            if (err) next[key] = err; else delete next[key];
+            return next;
+        });
     };
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
+        const found: Record<string, string> = {};
+        for (const field of schema) {
+            const err = validateField(field, data[field.key] ?? '');
+            if (err) found[field.key] = err;
+        }
+        setErrors(found);
+        if (Object.keys(found).length > 0) return;
         onSubmit(data);
     };
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} noValidate>
             <Grid container spacing={2}>
                 {schema.map((field) => (
                     <Grid size={{ xs: 12, sm: 6 }} key={field.key}>
-                        <FieldInput field={field} value={data[field.key] ?? ''} onChange={(v) => handleChange(field.key, v)} />
+                        <FieldInput
+                            field={field}
+                            value={data[field.key] ?? ''}
+                            error={errors[field.key]}
+                            onChange={(v) => handleChange(field.key, v)}
+                        />
                     </Grid>
                 ))}
                 <Grid size={{ xs: 12, sm: 6 }}>
@@ -51,10 +76,12 @@ const SchemaForm: React.FC<Props> = ({ schema, onSubmit, submitLabel = 'Send inn
 function FieldInput({
     field,
     value,
+    error,
     onChange,
 }: {
     field: FormFieldSchema;
     value: string;
+    error?: string;
     onChange: (v: string) => void;
 }) {
     switch (field.type) {
@@ -74,12 +101,13 @@ function FieldInput({
                         value={value}
                         onChange={(e) => onChange(e.target.value)}
                         margin="normal"
-                        helperText="Skriv inn fritekst — det er ingen forhåndsdefinerte valg satt opp."
+                        error={!!error}
+                        helperText={error ?? 'Skriv inn fritekst — det er ingen forhåndsdefinerte valg satt opp.'}
                     />
                 );
             }
             return (
-                <FormControl fullWidth required={!field.optional} margin="normal">
+                <FormControl fullWidth required={!field.optional} margin="normal" error={!!error}>
                     <InputLabel>{field.label}</InputLabel>
                     <Select
                         label={field.label}
@@ -92,6 +120,7 @@ function FieldInput({
                             </MenuItem>
                         ))}
                     </Select>
+                    {error && <FormHelperText>{error}</FormHelperText>}
                 </FormControl>
             );
         }
@@ -108,6 +137,8 @@ function FieldInput({
                     margin="normal"
                     multiline
                     rows={4}
+                    error={!!error}
+                    helperText={error}
                 />
             );
 
@@ -122,6 +153,8 @@ function FieldInput({
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     margin="normal"
+                    error={!!error}
+                    helperText={error}
                 />
             );
 
@@ -137,6 +170,8 @@ function FieldInput({
                     onChange={(e) => onChange(e.target.value)}
                     slotProps={{ inputLabel: { shrink: true } }}
                     margin="normal"
+                    error={!!error}
+                    helperText={error}
                 />
             );
 
@@ -151,6 +186,8 @@ function FieldInput({
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     margin="normal"
+                    error={!!error}
+                    helperText={error}
                 />
             );
     }

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -5,6 +5,25 @@ export const login = async (email: string, password: string): Promise<void> => {
     await nhost.auth.signInEmailPassword({ email, password });
 };
 
+/**
+ * Self-signup. A fresh account carries zero org memberships, so it grants
+ * no access by itself — an existing member must add the address via the
+ * Medlemmer page. Returns true if a session was established immediately,
+ * false when Nhost requires email verification first.
+ */
+export const signup = async (
+    email: string,
+    password: string,
+    displayName: string,
+): Promise<boolean> => {
+    const res = await nhost.auth.signUpEmailPassword({
+        email,
+        password,
+        options: displayName ? { displayName } : undefined,
+    });
+    return !!res.body?.session;
+};
+
 export const logout = async (): Promise<void> => {
     const session = nhost.getUserSession();
     await nhost.auth.signOut({ refreshToken: session?.refreshToken });

--- a/src/util/validateFormField.test.ts
+++ b/src/util/validateFormField.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { validateField } from "./validateFormField";
+import type { FormFieldSchema } from "@/types/formSchema";
+
+const f = (over: Partial<FormFieldSchema>): FormFieldSchema =>
+    ({ key: "k", label: "K", type: "text", ...over } as FormFieldSchema);
+
+describe("validateField", () => {
+    it("requires non-optional fields", () => {
+        expect(validateField(f({}), "")).toBe("Må fylles ut");
+        expect(validateField(f({}), "   ")).toBe("Må fylles ut");
+        expect(validateField(f({}), "x")).toBeNull();
+    });
+
+    it("allows empty optional fields", () => {
+        expect(validateField(f({ optional: true }), "")).toBeNull();
+    });
+
+    it("rejects unparseable dates but accepts ISO dates", () => {
+        expect(validateField(f({ type: "date" }), "ikke en dato")).toBe("Ugyldig dato");
+        expect(validateField(f({ type: "date" }), "2026-07-11")).toBeNull();
+    });
+
+    it("validates optional fields when they DO have a value", () => {
+        expect(validateField(f({ type: "date", optional: true }), "tull")).toBe("Ugyldig dato");
+    });
+
+    it("rejects non-numeric numbers", () => {
+        expect(validateField(f({ type: "number" }), "abc")).toBe("Må være et tall");
+        expect(validateField(f({ type: "number" }), "42")).toBeNull();
+    });
+});

--- a/src/util/validateFormField.ts
+++ b/src/util/validateFormField.ts
@@ -1,0 +1,25 @@
+import type { FormFieldSchema } from '@/types/formSchema';
+
+/**
+ * Client-side validation for one volunteer-form field.
+ * Returns a Norwegian error message, or null when the value is acceptable.
+ * Kept out of SchemaForm.tsx so it stays a pure, unit-testable module.
+ */
+export function validateField(field: FormFieldSchema, value: string): string | null {
+    const v = value.trim();
+    if (!v) {
+        return field.optional ? null : 'Må fylles ut';
+    }
+    switch (field.type) {
+        case 'date':
+            // <input type=date> gives yyyy-mm-dd, but pasted/prefilled data
+            // can be anything — reject what Date can't parse.
+            if (Number.isNaN(Date.parse(v))) return 'Ugyldig dato';
+            return null;
+        case 'number':
+            if (Number.isNaN(Number(v))) return 'Må være et tall';
+            return null;
+        default:
+            return null;
+    }
+}


### PR DESCRIPTION
Stacked on #17 (base is `claude/phase-3-onboarding` so the diff shows only phase 6 — the signup flow builds on phase 3's members page). Merge order: #16 → #17 → this, retargeting bases as each lands. Independent of the #18 → #19 stack.

## Volunteer form
- **Client-side validation** per the template's form schema: required-by-default (respects `optional`), date and number sanity checks, inline error messages that clear as the volunteer types. Pure logic lives in `src/util/validateFormField.ts` with unit tests. Notably this fixes required dropdowns, which MUI never enforced natively.
- **A real confirmation screen** after submit — what happens next, and that the data is deleted automatically when the attest is issued — replacing the old dialog that dropped you back onto the stale form.

## Verify page
- Unmistakable **green ✓ / red ✗** status with plain-language explanations (invalid = incomplete link, altered field, or never issued). The editable field grid is reframed as "attesterte opplysninger" you can perturb to watch verification fail.

## Self-signup
- `/registrer` via Nhost `signUpEmailPassword`. A fresh account carries **zero org memberships**, so it grants no access by itself — an existing member must still add the address on the Medlemmer page. Linked from the login page and the members-page helper text. Handles both Nhost modes (immediate session vs. email verification required).

## Verification
- Typecheck, lint, 104 tests (5 new), production build pass.
- Dev-server smoke: `/registrer`, `/login`, and the verify page all render the new states.
- Needs one manual pass against live Nhost: signup (check whether your project requires email verification) and an invalid/valid QR scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_