### PR TITLE
Phase 7: 24h retention TTL + platform-admin panel for creating orgs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ NHOST_ADMIN_SECRET=
 # Get from Nhost dashboard → Settings → Auth → JWT Secret (or the `key` field of NHOST_AUTH_JWT_CUSTOM_CLAIMS).
 # Must match the key Nhost uses to sign tokens. Server-only — never expose to client.
 NHOST_JWT_SECRET=
+
+# Optional: comma-separated account emails allowed to use the /admin panel
+# (create organizations, attach their first member). Unset = /admin disabled.
+PLATFORM_ADMIN_EMAILS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ row is gone; a second submitHash would fail the ownership check).
 Storing volunteer data indefinitely is NOT acceptable — do not remove the
 auto-delete.
 
+On top of that, unprocessed submissions expire: a lazy sweep
+(`src/lib/server/retention.ts`, TTL in `src/util/retention.ts`) deletes
+rows older than the TTL whenever the submissions API is touched. No
+scheduler exists on the edge runtime, and none is needed — if nothing
+triggers the sweep, nothing is reading the data either. Do not remove
+the sweep calls from the submissions GET/POST routes.
+
 ## The legacy `/verify` route
 
 Echo issued certificates before the multi-org migration. Their QR codes

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,165 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+    Box, Button, CircularProgress, Container, List, ListItem, ListItemText,
+    Paper, TextField, Typography,
+} from '@mui/material';
+import { authHeader } from '@/lib/nhost';
+import { useAuth } from '@/util/auth';
+import { useToast } from '@/components/ToastProvider';
+
+type Org = { id: string; slug: string; name: string };
+
+const PlatformAdminPage: React.FC = () => {
+    const user = useAuth();
+    const router = useRouter();
+    const toast = useToast();
+
+    const [orgs, setOrgs] = useState<Org[] | null>(null);
+    const [forbidden, setForbidden] = useState(false);
+    const [slug, setSlug] = useState('');
+    const [name, setName] = useState('');
+    const [adminEmail, setAdminEmail] = useState('');
+    const [busy, setBusy] = useState(false);
+
+    const load = useCallback(async () => {
+        try {
+            const res = await fetch('/api/admin/orgs', { headers: authHeader() });
+            if (res.status === 401 || res.status === 403) {
+                setForbidden(true);
+                return;
+            }
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            setOrgs(json.organizations);
+        } catch (e) {
+            toast.error(`Kunne ikke laste organisasjoner: ${(e as Error).message}`);
+            setOrgs([]);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        if (user === null) router.replace('/login');
+        if (user) load();
+    }, [user, router, load]);
+
+    const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (busy) return;
+        setBusy(true);
+        try {
+            const res = await fetch('/api/admin/orgs', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...authHeader() },
+                body: JSON.stringify({ slug, name, adminEmail }),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            toast.success(`Organisasjonen "${json.organization.name}" er opprettet med ${json.firstMember} som første medlem`);
+            setSlug(''); setName(''); setAdminEmail('');
+            await load();
+        } catch (err) {
+            toast.error((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (user === undefined || (user && orgs === null && !forbidden)) {
+        return (
+            <Container maxWidth="md" sx={{ py: 6, display: 'flex', justifyContent: 'center' }}>
+                <CircularProgress />
+            </Container>
+        );
+    }
+
+    if (forbidden) {
+        return (
+            <Container maxWidth="md" sx={{ py: 6 }}>
+                <Typography variant="h5" gutterBottom>Ingen tilgang</Typography>
+                <Typography variant="body1" color="text.secondary">
+                    Denne siden er kun for plattform-administratorer
+                    (styrt av <code>PLATFORM_ADMIN_EMAILS</code>).
+                </Typography>
+            </Container>
+        );
+    }
+
+    return (
+        <Container maxWidth="md" sx={{ py: 6 }}>
+            <Typography variant="h4" gutterBottom>Plattform-administrasjon</Typography>
+
+            <Paper sx={{ p: 3, mb: 3 }}>
+                <Typography variant="h6" gutterBottom>Opprett ny organisasjon</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Første medlem må allerede ha en brukerkonto (opprettes på /registrer).
+                    Medlemmet kan deretter selv legge til flere under «Medlemmer».
+                </Typography>
+                <Box component="form" onSubmit={handleCreate}
+                     sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                    <TextField
+                        size="small"
+                        label="Slug (URL-navn)"
+                        value={slug}
+                        onChange={(e) => setSlug(e.target.value.toLowerCase())}
+                        disabled={busy}
+                        helperText="Små bokstaver, tall, bindestrek"
+                    />
+                    <TextField
+                        size="small"
+                        label="Navn"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        disabled={busy}
+                    />
+                    <TextField
+                        size="small"
+                        type="email"
+                        label="Første medlems e-post"
+                        value={adminEmail}
+                        onChange={(e) => setAdminEmail(e.target.value)}
+                        disabled={busy}
+                        sx={{ minWidth: 240 }}
+                    />
+                    <Button type="submit" variant="contained"
+                            disabled={busy || !slug || !name || !adminEmail}
+                            sx={{ alignSelf: 'flex-start', mt: 0.25 }}>
+                        {busy ? <CircularProgress size={20} /> : 'Opprett'}
+                    </Button>
+                </Box>
+            </Paper>
+
+            <Paper sx={{ p: 3 }}>
+                <Typography variant="h6" gutterBottom>
+                    Organisasjoner ({orgs?.length ?? 0})
+                </Typography>
+                <List>
+                    {(orgs ?? []).map((org) => (
+                        <ListItem
+                            key={org.id}
+                            secondaryAction={
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                    <Button size="small" component={Link} href={`/org/${org.slug}`} target="_blank">
+                                        Skjema ↗
+                                    </Button>
+                                    <Button size="small" component={Link} href={`/login/adminpage/${org.slug}`}>
+                                        Admin
+                                    </Button>
+                                </Box>
+                            }
+                        >
+                            <ListItemText primary={org.name} secondary={`/org/${org.slug}`} />
+                        </ListItem>
+                    ))}
+                </List>
+            </Paper>
+        </Container>
+    );
+};
+
+export default PlatformAdminPage;

--- a/src/app/api/admin/orgs/route.ts
+++ b/src/app/api/admin/orgs/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { hasuraAdmin } from "@/lib/server/hasura";
+import { requirePlatformAdmin } from "@/lib/server/platformAdmin";
+import { getUserByEmail } from "@/lib/server/authUsers";
+
+export const runtime = "edge";
+
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const MAX_SLUG_LEN = 64;
+const MAX_NAME_LEN = 200;
+
+export async function GET(req: NextRequest) {
+    const auth = await requirePlatformAdmin(req);
+    if (auth instanceof NextResponse) return auth;
+
+    try {
+        const data = await hasuraAdmin<{
+            organizations: Array<{ id: string; slug: string; name: string }>;
+        }>(
+            `query AdminListOrgs {
+                organizations(order_by: { slug: asc }) { id slug name }
+            }`,
+        );
+        return NextResponse.json({ organizations: data.organizations });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}
+
+export async function POST(req: NextRequest) {
+    const auth = await requirePlatformAdmin(req);
+    if (auth instanceof NextResponse) return auth;
+
+    const { slug, name, adminEmail } = await req.json().catch(() => ({} as Record<string, unknown>));
+    if (typeof slug !== "string" || !SLUG_RE.test(slug) || slug.length > MAX_SLUG_LEN) {
+        return NextResponse.json(
+            { error: "Ugyldig slug — små bokstaver, tall og bindestrek" },
+            { status: 400 },
+        );
+    }
+    if (typeof name !== "string" || !name.trim() || name.length > MAX_NAME_LEN) {
+        return NextResponse.json({ error: "Ugyldig navn" }, { status: 400 });
+    }
+    if (typeof adminEmail !== "string" || !adminEmail.includes("@")) {
+        return NextResponse.json({ error: "Ugyldig e-postadresse for første medlem" }, { status: 400 });
+    }
+
+    try {
+        const existing = await hasuraAdmin<{ organizations: Array<{ id: string }> }>(
+            `query OrgExists($slug: String!) {
+                organizations(where: { slug: { _eq: $slug } }, limit: 1) { id }
+            }`,
+            { slug },
+        );
+        if (existing.organizations.length > 0) {
+            return NextResponse.json({ error: `Organisasjonen "${slug}" finnes allerede` }, { status: 409 });
+        }
+
+        const user = await getUserByEmail(adminEmail.trim().toLowerCase());
+        if (!user) {
+            return NextResponse.json(
+                { error: "Fant ingen brukerkonto for e-posten. Be personen registrere seg på /registrer først." },
+                { status: 404 },
+            );
+        }
+
+        // Client-generated org id lets both inserts share one mutation —
+        // Hasura runs the root fields in a single transaction, so we never
+        // end up with a memberless org on partial failure.
+        const orgId = crypto.randomUUID();
+        await hasuraAdmin(
+            `mutation CreateOrgWithMember($orgId: uuid!, $slug: String!, $name: String!, $userId: uuid!) {
+                insert_organizations_one(object: { id: $orgId, slug: $slug, name: $name }) { id }
+                insert_user_organizations_one(object: { user_id: $userId, organization_id: $orgId }) { user_id }
+            }`,
+            { orgId, slug, name: name.trim(), userId: user.id },
+        );
+        return NextResponse.json({
+            organization: { id: orgId, slug, name: name.trim() },
+            firstMember: user.email,
+        });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}

--- a/src/app/api/org/[slug]/submissions/route.ts
+++ b/src/app/api/org/[slug]/submissions/route.ts
@@ -3,6 +3,7 @@ import { hasuraAdmin } from "@/lib/server/hasura";
 import { requireOrgMemberBySlug, resolveOrgIdBySlug } from "@/lib/server/apiAuth";
 import { templateBelongsToOrg } from "@/lib/server/ownership";
 import { checkRateLimit, clientIp } from "@/lib/server/rateLimit";
+import { sweepExpiredSubmissions } from "@/lib/server/retention";
 
 export const runtime = "edge";
 
@@ -33,6 +34,10 @@ export async function GET(
     const { slug } = await params;
     const auth = await requireOrgMemberBySlug(req, slug);
     if (auth instanceof NextResponse) return auth;
+
+    // Enforce the retention TTL before reading, so the admin never sees
+    // (and the response never contains) rows that should already be gone.
+    await sweepExpiredSubmissions();
 
     try {
         const data = await hasuraAdmin<{ submissions: SubmissionRow[] }>(
@@ -91,6 +96,10 @@ export async function POST(
             return NextResponse.json({ error: `Field "${k}" is too long` }, { status: 413 });
         }
     }
+
+    // Piggyback the retention sweep on the anonymous write path too, so
+    // expired rows are purged even if no admin logs in for days.
+    await sweepExpiredSubmissions();
 
     try {
         const organizationId = await resolveOrgIdBySlug(slug);

--- a/src/app/login/adminpage/[orgSlug]/page.tsx
+++ b/src/app/login/adminpage/[orgSlug]/page.tsx
@@ -16,6 +16,7 @@ import SchemaDetails from '@/components/SchemaDetails';
 import { useToast } from '@/components/ToastProvider';
 import type { Submission } from '@/types/submission';
 import type { FormSchema } from '@/types/formSchema';
+import { hoursUntilDeletion } from '@/util/retention';
 
 type SubmissionRow = {
     id: string;
@@ -233,6 +234,9 @@ const AdminPage: React.FC = () => {
                                             Mal: {tmpl.name}
                                         </Typography>
                                     )}
+                                    <Typography variant="caption" color="warning.main" display="block">
+                                        Slettes automatisk om {hoursUntilDeletion(sub.createdAt)} t
+                                    </Typography>
                                     {schema ? (
                                         <SchemaDetails schema={schema} data={sub.data} />
                                     ) : (

--- a/src/app/orgSubmissionForm.tsx
+++ b/src/app/orgSubmissionForm.tsx
@@ -9,6 +9,7 @@ import SchemaForm from '@/components/SchemaForm';
 import SchemaDetails from '@/components/SchemaDetails';
 import { useToast } from '@/components/ToastProvider';
 import ConfirmDialog from "@/util/confirmDialog";
+import { SUBMISSION_TTL_HOURS } from '@/util/retention';
 
 interface Props {
     orgSlug: string;
@@ -115,6 +116,8 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
                         <li>Godkjennes de, lages attesten som PDF med QR-kode, og du får den fra {orgName}.</li>
                         <li>I samme øyeblikk slettes opplysningene dine fra databasen — bare en
                             kryptografisk hash blir igjen, så attesten kan verifiseres.</li>
+                        <li>Behandles ikke innsendingen innen {SUBMISSION_TTL_HOURS} timer,
+                            slettes den automatisk. Da må du sende inn på nytt.</li>
                     </Typography>
                     <Button variant="outlined" onClick={() => { setFormData({}); setSubmitted(false); }}>
                         Send inn en ny

--- a/src/lib/server/platformAdmin.ts
+++ b/src/lib/server/platformAdmin.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/server/apiAuth";
+import { getUsersByIds } from "@/lib/server/authUsers";
+
+// Platform admins sit above the org level: they may create organizations
+// and attach their first member. Membership in the club is an env-var
+// allowlist of account emails (comma-separated) — deliberately not a
+// database role, so it stays code-only and can't be self-granted through
+// any app surface. Unset = the /admin surface is disabled entirely.
+
+function allowlist(): Set<string> {
+    return new Set(
+        (process.env.PLATFORM_ADMIN_EMAILS ?? "")
+            .split(",")
+            .map((e) => e.trim().toLowerCase())
+            .filter(Boolean),
+    );
+}
+
+/**
+ * Verify the caller's session AND that their account email is on the
+ * platform-admin allowlist. Returns { userId, email } or a 401/403.
+ * The email is read from the auth.users row, not from client input.
+ */
+export async function requirePlatformAdmin(
+    req: NextRequest,
+): Promise<{ userId: string; email: string } | NextResponse> {
+    const session = await requireSession(req);
+    if (session instanceof NextResponse) return session;
+
+    const admins = allowlist();
+    if (admins.size === 0) {
+        return NextResponse.json({ error: "Platform admin is not configured" }, { status: 403 });
+    }
+
+    const [user] = await getUsersByIds([session.userId]);
+    const email = user?.email?.toLowerCase();
+    if (!email || !admins.has(email)) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return { userId: session.userId, email };
+}

--- a/src/lib/server/retention.ts
+++ b/src/lib/server/retention.ts
@@ -1,0 +1,27 @@
+import { hasuraAdmin } from "@/lib/server/hasura";
+import { retentionCutoffIso } from "@/util/retention";
+
+/**
+ * Delete every submission older than the TTL, across all orgs. Runs lazily
+ * whenever the submissions API is touched — no scheduler needed on the edge
+ * runtime, and if nothing ever triggers it, nothing is reading the data
+ * either; the next interaction cleans up.
+ *
+ * Deliberately org-UNscoped: this is a platform privacy guarantee, not a
+ * tenant feature, and it only ever deletes. Never throws — an expired-row
+ * sweep must not break the request that triggered it.
+ */
+export async function sweepExpiredSubmissions(): Promise<void> {
+    try {
+        await hasuraAdmin(
+            `mutation SweepExpired($cutoff: timestamptz!) {
+                delete_submissions(where: { created_at: { _lt: $cutoff } }) {
+                    affected_rows
+                }
+            }`,
+            { cutoff: retentionCutoffIso() },
+        );
+    } catch (e) {
+        console.error("Retention sweep failed:", (e as Error).message);
+    }
+}

--- a/src/util/retention.test.ts
+++ b/src/util/retention.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { hoursUntilDeletion, retentionCutoffIso, SUBMISSION_TTL_HOURS } from "./retention";
+
+const HOUR = 60 * 60 * 1000;
+
+describe("retentionCutoffIso", () => {
+    it("is exactly TTL hours before now", () => {
+        const now = Date.parse("2026-07-11T12:00:00.000Z");
+        expect(retentionCutoffIso(now)).toBe(
+            new Date(now - SUBMISSION_TTL_HOURS * HOUR).toISOString(),
+        );
+    });
+});
+
+describe("hoursUntilDeletion", () => {
+    const now = Date.parse("2026-07-11T12:00:00.000Z");
+
+    it("counts down from the full TTL for a brand new submission", () => {
+        expect(hoursUntilDeletion(new Date(now), now)).toBe(SUBMISSION_TTL_HOURS);
+    });
+
+    it("rounds partial hours up", () => {
+        const created = new Date(now - 2.5 * HOUR);
+        expect(hoursUntilDeletion(created, now)).toBe(SUBMISSION_TTL_HOURS - 2);
+    });
+
+    it("never goes negative for already-expired rows", () => {
+        const created = new Date(now - (SUBMISSION_TTL_HOURS + 5) * HOUR);
+        expect(hoursUntilDeletion(created, now)).toBe(0);
+    });
+});

--- a/src/util/retention.ts
+++ b/src/util/retention.ts
@@ -1,0 +1,20 @@
+// Submission time-to-live. A submission that is never processed is deleted
+// automatically this many hours after creation — the safety net that makes
+// "volunteer data never lives long in the database" true even when no admin
+// ever touches the queue. Enforced lazily by the submissions API (see
+// src/lib/server/retention.ts); shown to admins on the dashboard and to
+// volunteers on the confirmation screen.
+//
+// Isomorphic module: imported by both server routes and client components.
+export const SUBMISSION_TTL_HOURS = 24;
+
+/** ISO timestamp for "TTL ago" — rows created before this are expired. */
+export function retentionCutoffIso(now: number = Date.now()): string {
+    return new Date(now - SUBMISSION_TTL_HOURS * 60 * 60 * 1000).toISOString();
+}
+
+/** Whole hours until a submission created at `createdAt` is deleted (min 0). */
+export function hoursUntilDeletion(createdAt: Date, now: number = Date.now()): number {
+    const deleteAt = createdAt.getTime() + SUBMISSION_TTL_HOURS * 60 * 60 * 1000;
+    return Math.max(0, Math.ceil((deleteAt - now) / (60 * 60 * 1000)));
+}


### PR DESCRIPTION
Stacked on #20 (chain: #16 → #17 → #20 → this). Retarget bases downward as parents merge.

## Retention: submissions expire after 24 hours
- A **lazy sweep** deletes any submission older than the TTL whenever the submissions API is touched (admin dashboard load, new public submission). No cron/scheduler needed on the edge runtime — and if nothing ever triggers the sweep, nothing is reading the data either.
- Surfaced everywhere it matters: dashboard cards show *"Slettes automatisk om X t"*, the volunteer confirmation screen explains that an unprocessed submission is deleted and must be resubmitted, and CLAUDE.md documents the guarantee as load-bearing.
- TTL is one constant (`SUBMISSION_TTL_HOURS` in `src/util/retention.ts`) — change it there if 24h proves too aggressive for weekend-paced orgs. #18's email notification is what makes a short TTL comfortable in practice.

## Platform-admin panel: create orgs without SQL
- **`/admin`** lists all organizations and creates a new one with its first member attached — org row + membership in **one Hasura transaction** (client-generated uuid ties the two inserts).
- Access is an env allowlist: `PLATFORM_ADMIN_EMAILS` (comma-separated account emails; unset = the whole surface is disabled). The check reads the caller's email from `auth.users` server-side — never from client input — and it's deliberately not a database role, so it can't be self-granted through any app surface.
- Flow for a new org: person registers at `/registrer` → you create the org at `/admin` with their email → they invite colleagues via *Medlemmer*. Zero SQL. `scripts/create-org.ts` remains for CLI use.

## Deploy notes
- Set `PLATFORM_ADMIN_EMAILS` in Cloudflare Pages (e.g. your own email) to enable `/admin`.
- When this and #18 have both landed, add `/admin` to the robots.txt disallow list (robots.ts lives in the other stack — one-line follow-up).

## Verification
- Typecheck, lint, 108 tests (4 new for cutoff/countdown math), production build pass; `/admin` smoke-rendered on the dev server.
- Needs a live pass: create an org via `/admin`, confirm an old submission disappears after the sweep triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_