### PR TITLE
Phase 8: Playwright E2E smoke suite — verify contract, form flow, landing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,30 @@ jobs:
           # Pages project. The build only needs them to exist.
           NEXT_PUBLIC_NHOST_SUBDOMAIN: ci-placeholder
           NEXT_PUBLIC_NHOST_REGION: eu-central-1
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke suite
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ tsconfig.tsbuildinfo
 
 # Next.js generated types
 next-env.d.ts
+
+# Playwright artifacts
+/test-results/
+/playwright-report/

--- a/e2e/form.spec.ts
+++ b/e2e/form.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+const ORG = 'testorg';
+
+const TEMPLATE = {
+    id: '22222222-2222-2222-2222-222222222222',
+    name: 'Standardattest',
+    form_schema: [
+        { key: 'name', label: 'Navn', type: 'text' },
+        { key: 'start', label: 'Fra dato', type: 'date' },
+        { key: 'notat', label: 'Notat', type: 'text', optional: true },
+    ],
+};
+
+test.beforeEach(async ({ page }) => {
+    await page.route(`**/api/org/${ORG}`, (route) =>
+        route.fulfill({ json: { organization: { id: 'org-1', slug: ORG, name: 'Testorg' } } }),
+    );
+    await page.route(`**/api/org/${ORG}/default-template`, (route) =>
+        route.fulfill({ json: { template: TEMPLATE } }),
+    );
+});
+
+test('empty required fields show inline errors and block submission', async ({ page }) => {
+    await page.goto(`/org/${ORG}`);
+    await expect(page.getByText('Søk om attest til Testorg')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Send inn' }).click();
+
+    // Two required fields empty → two inline errors; the optional one none.
+    await expect(page.getByText('Må fylles ut')).toHaveCount(2);
+    await expect(page.getByText('Bekreft innsending')).not.toBeVisible();
+});
+
+test('valid submission reaches the confirmation screen', async ({ page }) => {
+    await page.route(`**/api/org/${ORG}/submissions`, (route) =>
+        route.fulfill({ json: { submission: { id: 'sub-1', created_at: '2026-07-11T00:00:00Z' } } }),
+    );
+
+    await page.goto(`/org/${ORG}`);
+    await page.getByLabel('Navn').fill('Ola Nordmann');
+    await page.getByLabel('Fra dato').fill('2026-01-15');
+    await page.getByRole('button', { name: 'Send inn' }).click();
+
+    await expect(page.getByText('Bekreft innsending')).toBeVisible();
+    await page.getByRole('button', { name: 'Ja, lagre' }).click();
+
+    await expect(page.getByText('Innsendingen er mottatt')).toBeVisible();
+    await expect(page.getByText('slettes den automatisk')).toBeVisible();
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Node-side mirror of src/util/canonicalHash.ts (drop `t`, sort keys,
+ * join k=v with &, SHA-512 hex). Reimplemented with node:crypto instead of
+ * imported so the e2e suite has no dependency on the app's tsconfig paths —
+ * certRoundTrip.test.ts already guards the algorithm itself.
+ */
+export function certHash(fields: Record<string, string>): string {
+    const sorted = Object.entries(fields)
+        .filter(([k]) => k !== 't')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&');
+    return createHash('sha512').update(sorted, 'utf8').digest('hex');
+}

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+
+// The landing page fetches the org directory server-side; with the
+// placeholder Nhost env that fetch fails and the page must still render
+// (directory gracefully omitted) — which is exactly what we assert.
+test('landing page renders without a database', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'attester.no' })).toBeVisible();
+    await expect(page.getByText('Personvern er hele poenget')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Logg inn som administrator' })).toBeVisible();
+});

--- a/e2e/verify.spec.ts
+++ b/e2e/verify.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { certHash } from './helpers';
+
+const ORG = 'testorg';
+const TEMPLATE_ID = '11111111-1111-1111-1111-111111111111';
+const SUBMISSION_ID = 'sub-e2e-1';
+
+const CERT_FIELDS = {
+    id: SUBMISSION_ID,
+    name: 'Ola Nordmann',
+    group: 'Kjelleren',
+};
+
+const FORM_SCHEMA = [
+    { key: 'name', label: 'Navn', type: 'text' },
+    { key: 'group', label: 'Gruppe', type: 'text' },
+];
+
+test.beforeEach(async ({ page }) => {
+    // The verify page recomputes the hash client-side from the URL params
+    // and compares it to what "the server" returns — so mocking the two
+    // API routes exercises the full verification contract in the browser.
+    await page.route(`**/api/org/${ORG}/certificates/verify*`, (route) =>
+        route.fulfill({ json: { hash: certHash(CERT_FIELDS), template_id: TEMPLATE_ID } }),
+    );
+    await page.route(`**/api/org/${ORG}/templates/${TEMPLATE_ID}*`, (route) =>
+        route.fulfill({ json: { template: { id: TEMPLATE_ID, form_schema: FORM_SCHEMA } } }),
+    );
+});
+
+function verifyUrl(fields: Record<string, string>): string {
+    const params = new URLSearchParams({ t: TEMPLATE_ID, ...fields });
+    return `/org/${ORG}/verify?${params.toString()}`;
+}
+
+test('matching params verify green', async ({ page }) => {
+    await page.goto(verifyUrl(CERT_FIELDS));
+    await expect(page.getByText('✓ Attesten er gyldig')).toBeVisible();
+    await expect(page.getByLabel('Navn')).toHaveValue('Ola Nordmann');
+});
+
+test('tampered params verify red', async ({ page }) => {
+    await page.goto(verifyUrl({ ...CERT_FIELDS, name: 'Kari Nordmann' }));
+    await expect(page.getByText('✗ Attesten er ugyldig')).toBeVisible();
+});
+
+test('editing a field flips a green verification to red', async ({ page }) => {
+    await page.goto(verifyUrl(CERT_FIELDS));
+    await expect(page.getByText('✓ Attesten er gyldig')).toBeVisible();
+
+    await page.getByLabel('Gruppe').fill('Styret');
+    await expect(page.getByText('✗ Attesten er ugyldig')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@cloudflare/next-on-pages": "^1.13.16",
         "@eslint/eslintrc": "^3.3.5",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^25",
         "@types/react": "19.2.8",
         "@types/react-dom": "19.2.3",
@@ -3081,6 +3082,22 @@
       "peer": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -12498,6 +12515,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "pages:build": "npx @cloudflare/next-on-pages",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.16",
     "@eslint/eslintrc": "^3.3.5",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^25",
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E smoke suite. Every backend call the pages make is mocked with
+// page.route() inside the tests, so no Nhost project is needed — the
+// placeholder env vars below only have to exist for next dev to boot.
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    retries: process.env.CI ? 2 : 0,
+    reporter: process.env.CI ? 'github' : 'list',
+    use: {
+        baseURL: 'http://localhost:3900',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                // Sandboxed environments can provide a system chromium via
+                // PW_CHROMIUM_PATH instead of `playwright install`; CI and
+                // normal dev machines leave it unset and use the managed one.
+                launchOptions: process.env.PW_CHROMIUM_PATH
+                    ? { executablePath: process.env.PW_CHROMIUM_PATH }
+                    : {},
+            },
+        },
+    ],
+    webServer: {
+        command: 'npx next dev -p 3900',
+        url: 'http://localhost:3900',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+            NEXT_PUBLIC_NHOST_SUBDOMAIN: 'e2e-placeholder',
+            NEXT_PUBLIC_NHOST_REGION: 'eu-central-1',
+        },
+    },
+});


### PR DESCRIPTION
Stacked on #21 (chain: #16 → #17 → #20 → #21 → this). Retarget bases downward as parents merge.

## What it covers
Browser-level tests with mocked API responses — no Nhost project needed, so they run anywhere including CI:

- **The verification contract** (the product's core promise): a QR URL whose params match the stored hash renders green; a tampered param renders red; editing a field flips a green verification to red live. The test computes the expected SHA-512 exactly like `canonicalHash` does, so drift in either the page or the algorithm fails the suite.
- **The volunteer form**: empty required fields show inline errors and block the confirm dialog; a valid submission walks confirm → the "Innsendingen er mottatt" screen including the 24h retention notice.
- **The landing page** renders with the database unreachable (directory gracefully omitted).

## Plumbing
- `playwright.config.ts` boots `next dev` with placeholder env; `npm run test:e2e`.
- New `e2e` CI job installs chromium and uploads the report on failure. Vitest and Playwright don't collide (vitest is scoped to `src/**/*.test.ts`).
- Sandboxes with a pre-provisioned chromium can set `PW_CHROMIUM_PATH` instead of downloading.

## Verification
- All 6 E2E tests pass locally (25s), plus the usual typecheck/lint/108 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_