### PR TITLE
Phase 10: anonymous volunteer feedback — rating + comment to org admins

### DIFF
--- a/e2e/form.spec.ts
+++ b/e2e/form.spec.ts
@@ -48,3 +48,31 @@ test('valid submission reaches the confirmation screen', async ({ page }) => {
     await expect(page.getByText('Innsendingen er mottatt')).toBeVisible();
     await expect(page.getByText('slettes den automatisk')).toBeVisible();
 });
+
+test('confirmation screen accepts anonymous feedback', async ({ page }) => {
+    await page.route(`**/api/org/${ORG}/submissions`, (route) =>
+        route.fulfill({ json: { submission: { id: 'sub-1', created_at: '2026-07-11T00:00:00Z' } } }),
+    );
+    let feedbackBody: unknown = null;
+    await page.route(`**/api/org/${ORG}/feedback`, async (route) => {
+        feedbackBody = route.request().postDataJSON();
+        await route.fulfill({ json: { ok: true } });
+    });
+
+    await page.goto(`/org/${ORG}`);
+    await page.getByLabel('Navn').fill('Ola Nordmann');
+    await page.getByLabel('Fra dato').fill('2026-01-15');
+    await page.getByRole('button', { name: 'Send inn' }).click();
+    await page.getByRole('button', { name: 'Ja, lagre' }).click();
+    await expect(page.getByText('Innsendingen er mottatt')).toBeVisible();
+
+    // Rate 4 stars, add a comment, send. MUI Rating's radio inputs are
+    // visually hidden and its state changes via the star labels, so click
+    // the 4th label (index 3) rather than the input.
+    await page.locator('.MuiRating-root label').nth(3).click();
+    await page.getByLabel('Kommentar (valgfritt)').fill('Veldig enkelt!');
+    await page.getByRole('button', { name: 'Send tilbakemelding' }).click();
+
+    await expect(page.getByText('Takk for tilbakemeldingen!')).toBeVisible();
+    expect(feedbackBody).toEqual({ rating: 4, comment: 'Veldig enkelt!' });
+});

--- a/scripts/migrations/0000-baseline-schema.sql
+++ b/scripts/migrations/0000-baseline-schema.sql
@@ -108,6 +108,17 @@ CREATE TABLE IF NOT EXISTS legacy_certificates (
 );
 CREATE INDEX IF NOT EXISTS legacy_certificates_volunteer_idx ON legacy_certificates(volunteer_id);
 
+-- Anonymous platform feedback from volunteers, shown to the org's admins.
+-- Carries NO identity by design: no user id, no submission reference.
+CREATE TABLE IF NOT EXISTS feedback (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    rating int NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    comment text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS feedback_org_idx ON feedback(organization_id, created_at DESC);
+
 -- Hasura console steps (fresh install):
 --   1. Data → "Untracked tables/views" → track every table above.
 --   2. Relationships: object relationships on each organization_id /

--- a/scripts/migrations/2026-07-feedback.sql
+++ b/scripts/migrations/2026-07-feedback.sql
@@ -1,0 +1,15 @@
+-- Anonymous platform feedback from volunteers, shown to the org's admins.
+-- Carries NO identity by design: no user id, no submission reference, no IP.
+-- The UI tells the writer not to include personal data in the comment.
+--
+-- Run in the Hasura SQL console, then track the table (no relationships
+-- needed — the API resolves the org by slug itself).
+
+CREATE TABLE IF NOT EXISTS feedback (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    rating int NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    comment text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS feedback_org_idx ON feedback(organization_id, created_at DESC);

--- a/src/app/api/org/[slug]/feedback/route.ts
+++ b/src/app/api/org/[slug]/feedback/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { hasuraAdmin } from "@/lib/server/hasura";
+import { requireOrgMemberBySlug, resolveOrgIdBySlug } from "@/lib/server/apiAuth";
+import { checkRateLimit, clientIp } from "@/lib/server/rateLimit";
+
+export const runtime = "edge";
+
+const MAX_COMMENT_LEN = 2000;
+
+// Anonymous endpoint → throttle like the submissions POST, but tighter:
+// nobody legitimately leaves many ratings from one machine.
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 10 * 60 * 1000;
+
+type FeedbackRow = { id: string; rating: number; comment: string; created_at: string };
+
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    const auth = await requireOrgMemberBySlug(req, slug);
+    if (auth instanceof NextResponse) return auth;
+
+    try {
+        const data = await hasuraAdmin<{ feedback: FeedbackRow[] }>(
+            `query GetFeedback($organizationId: uuid!) {
+                feedback(
+                    where: { organization_id: { _eq: $organizationId } },
+                    order_by: { created_at: desc }
+                ) { id rating comment created_at }
+            }`,
+            { organizationId: auth.organizationId },
+        );
+        return NextResponse.json({ feedback: data.feedback });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}
+
+export async function POST(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    if (!checkRateLimit(`feedback:${clientIp(req.headers)}`, RATE_LIMIT, RATE_WINDOW_MS)) {
+        return NextResponse.json({ error: "For mange tilbakemeldinger. Prøv igjen senere." }, { status: 429 });
+    }
+
+    const { rating, comment } = await req.json().catch(() => ({} as Record<string, unknown>));
+    if (!Number.isInteger(rating) || (rating as number) < 1 || (rating as number) > 5) {
+        return NextResponse.json({ error: "Rating must be an integer 1-5" }, { status: 400 });
+    }
+    if (comment !== undefined && typeof comment !== "string") {
+        return NextResponse.json({ error: "Comment must be a string" }, { status: 400 });
+    }
+    if (typeof comment === "string" && comment.length > MAX_COMMENT_LEN) {
+        return NextResponse.json({ error: "Comment is too long" }, { status: 413 });
+    }
+
+    try {
+        const organizationId = await resolveOrgIdBySlug(slug);
+        if (!organizationId) {
+            return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+        }
+        await hasuraAdmin(
+            `mutation InsertFeedback($organizationId: uuid!, $rating: Int!, $comment: String!) {
+                insert_feedback_one(object: {
+                    organization_id: $organizationId,
+                    rating: $rating,
+                    comment: $comment
+                }) { id }
+            }`,
+            { organizationId, rating, comment: (comment as string | undefined)?.trim() ?? "" },
+        );
+        return NextResponse.json({ ok: true });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    req: NextRequest,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    const { slug } = await params;
+    const auth = await requireOrgMemberBySlug(req, slug);
+    if (auth instanceof NextResponse) return auth;
+
+    const { id } = await req.json().catch(() => ({} as { id?: unknown }));
+    if (typeof id !== "string" || !id) {
+        return NextResponse.json({ error: "Missing id" }, { status: 400 });
+    }
+
+    try {
+        // Org-scoped delete: the where clause pins the org id from the
+        // membership check, so an admin can't delete another org's rows.
+        await hasuraAdmin(
+            `mutation DeleteFeedback($id: uuid!, $organizationId: uuid!) {
+                delete_feedback(where: {
+                    id: { _eq: $id },
+                    organization_id: { _eq: $organizationId }
+                }) { affected_rows }
+            }`,
+            { id, organizationId: auth.organizationId },
+        );
+        return NextResponse.json({ ok: true });
+    } catch (e) {
+        return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+    }
+}

--- a/src/app/login/adminpage/[orgSlug]/layout.tsx
+++ b/src/app/login/adminpage/[orgSlug]/layout.tsx
@@ -76,6 +76,14 @@ export default function OrgAdminLayout({ children }: { children: React.ReactNode
                     </Button>
                     <Button
                         component={Link}
+                        href={`/login/adminpage/${orgSlug}/tilbakemeldinger`}
+                        variant="outlined"
+                        size="small"
+                    >
+                        Tilbakemeldinger
+                    </Button>
+                    <Button
+                        component={Link}
                         href={`/org/${orgSlug}`}
                         target="_blank"
                         rel="noreferrer"

--- a/src/app/login/adminpage/[orgSlug]/tilbakemeldinger/page.tsx
+++ b/src/app/login/adminpage/[orgSlug]/tilbakemeldinger/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+export const runtime = 'edge';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+    Box, CircularProgress, IconButton, Paper, Rating, Typography,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { authHeader } from '@/lib/nhost';
+import { useToast } from '@/components/ToastProvider';
+
+type FeedbackItem = { id: string; rating: number; comment: string; created_at: string };
+
+const FeedbackPage: React.FC = () => {
+    const { orgSlug } = useParams<{ orgSlug: string }>();
+    const toast = useToast();
+    const [items, setItems] = useState<FeedbackItem[] | null>(null);
+
+    const load = useCallback(async () => {
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/feedback`, {
+                headers: authHeader(),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            setItems(json.feedback);
+        } catch (e) {
+            toast.error(`Kunne ikke laste tilbakemeldinger: ${(e as Error).message}`);
+            setItems([]);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [orgSlug]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const handleDelete = async (id: string) => {
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/feedback`, {
+                method: 'DELETE',
+                headers: { 'content-type': 'application/json', ...authHeader() },
+                body: JSON.stringify({ id }),
+            });
+            const json = await res.json();
+            if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+            setItems((prev) => (prev ?? []).filter((f) => f.id !== id));
+        } catch (e) {
+            toast.error((e as Error).message);
+        }
+    };
+
+    const average = items && items.length > 0
+        ? items.reduce((sum, f) => sum + f.rating, 0) / items.length
+        : null;
+
+    return (
+        <>
+            <Typography variant="h4" gutterBottom>Tilbakemeldinger</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Anonyme tilbakemeldinger fra innsendere etter at skjemaet er sendt inn.
+            </Typography>
+
+            {items === null ? (
+                <CircularProgress />
+            ) : items.length === 0 ? (
+                <Paper sx={{ p: 3 }}>
+                    <Typography variant="body2" color="text.secondary">
+                        Ingen tilbakemeldinger enda. De dukker opp her når innsendere
+                        vurderer opplevelsen på bekreftelsessiden.
+                    </Typography>
+                </Paper>
+            ) : (
+                <>
+                    <Paper sx={{ p: 2, mb: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+                        <Rating value={average} precision={0.1} readOnly />
+                        <Typography variant="body2" color="text.secondary">
+                            {average?.toFixed(1)} i snitt · {items.length} tilbakemelding{items.length === 1 ? '' : 'er'}
+                        </Typography>
+                    </Paper>
+                    {items.map((f) => (
+                        <Paper key={f.id} sx={{ p: 2, mb: 1.5 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                                    <Rating value={f.rating} readOnly size="small" />
+                                    <Typography variant="caption" color="text.secondary">
+                                        {new Date(f.created_at).toLocaleString('nb-NO')}
+                                    </Typography>
+                                </Box>
+                                <IconButton
+                                    size="small"
+                                    aria-label="Slett tilbakemelding"
+                                    onClick={() => handleDelete(f.id)}
+                                >
+                                    <DeleteIcon fontSize="small" />
+                                </IconButton>
+                            </Box>
+                            {f.comment && (
+                                <Typography variant="body2" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>
+                                    {f.comment}
+                                </Typography>
+                            )}
+                        </Paper>
+                    ))}
+                </>
+            )}
+        </>
+    );
+};
+
+export default FeedbackPage;

--- a/src/app/orgSubmissionForm.tsx
+++ b/src/app/orgSubmissionForm.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/components/ToastProvider';
 import ConfirmDialog from "@/util/confirmDialog";
 import { getStrings } from '@/strings';
 import LanguageToggle from '@/components/LanguageToggle';
+import FeedbackWidget from '@/components/FeedbackWidget';
 
 interface Props {
     orgSlug: string;
@@ -121,6 +122,7 @@ const OrgSubmissionForm: React.FC<Props> = ({ orgSlug }) => {
                     <Button variant="outlined" onClick={() => { setFormData({}); setSubmitted(false); }}>
                         {s.sendAnother}
                     </Button>
+                    <FeedbackWidget orgSlug={orgSlug} strings={strings.feedback} />
                 </Paper>
             </Container>
         );

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,0 +1,95 @@
+'use client'
+import React, { useState } from 'react';
+import { Box, Button, CircularProgress, Rating, TextField, Typography } from '@mui/material';
+import type { Strings } from '@/strings';
+
+interface Props {
+    orgSlug: string;
+    strings: Strings['feedback'];
+}
+
+/**
+ * Anonymous rating + optional comment, POSTed to the org's feedback API.
+ * Shown on the volunteer confirmation screen. Deliberately carries no
+ * identity — the API stores only org, rating, comment, timestamp.
+ */
+const FeedbackWidget: React.FC<Props> = ({ orgSlug, strings }) => {
+    const [rating, setRating] = useState<number | null>(null);
+    const [comment, setComment] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [sent, setSent] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    if (sent) {
+        return (
+            <Typography variant="body2" color="success.main" sx={{ mt: 2 }}>
+                {strings.thanks}
+            </Typography>
+        );
+    }
+
+    const handleSend = async () => {
+        if (!rating || busy) return;
+        setBusy(true);
+        setError(null);
+        try {
+            const res = await fetch(`/api/org/${encodeURIComponent(orgSlug)}/feedback`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ rating, comment: comment.trim() || undefined }),
+            });
+            if (!res.ok) {
+                const json = await res.json().catch(() => ({} as { error?: string }));
+                throw new Error(json.error ?? `HTTP ${res.status}`);
+            }
+            setSent(true);
+        } catch (e) {
+            setError(`${strings.error}: ${(e as Error).message}`);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: 'divider', textAlign: 'left' }}>
+            <Typography variant="subtitle2" gutterBottom>{strings.title}</Typography>
+            <Rating
+                value={rating}
+                onChange={(_, v) => setRating(v)}
+                size="large"
+                disabled={busy}
+            />
+            {rating !== null && (
+                <>
+                    <TextField
+                        fullWidth
+                        multiline
+                        rows={2}
+                        size="small"
+                        label={strings.commentLabel}
+                        helperText={strings.commentHint}
+                        value={comment}
+                        onChange={(e) => setComment(e.target.value)}
+                        disabled={busy}
+                        sx={{ mt: 1 }}
+                        slotProps={{ htmlInput: { maxLength: 2000 } }}
+                    />
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={handleSend}
+                        disabled={busy}
+                        sx={{ mt: 1 }}
+                    >
+                        {busy ? <CircularProgress size={18} /> : strings.send}
+                    </Button>
+                </>
+            )}
+            {error && (
+                <Typography variant="body2" color="error" sx={{ mt: 1 }}>{error}</Typography>
+            )}
+        </Box>
+    );
+};
+
+export default FeedbackWidget;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -145,6 +145,14 @@ const no = {
         invalidNumber: 'Må være et tall',
         dropdownFallback: 'Skriv inn fritekst — det er ingen forhåndsdefinerte valg satt opp.',
     },
+    feedback: {
+        title: 'Hvordan var det å bruke attester.no?',
+        commentLabel: 'Kommentar (valgfritt)',
+        commentHint: 'Ikke skriv personopplysninger her — tilbakemeldingen er anonym.',
+        send: 'Send tilbakemelding',
+        thanks: 'Takk for tilbakemeldingen!',
+        error: 'Kunne ikke sende tilbakemeldingen',
+    },
 };
 
 const en: Strings = {
@@ -279,6 +287,14 @@ const en: Strings = {
         invalidDate: 'Invalid date',
         invalidNumber: 'Must be a number',
         dropdownFallback: 'Free text — no predefined options are set up.',
+    },
+    feedback: {
+        title: 'How was your experience with attester.no?',
+        commentLabel: 'Comment (optional)',
+        commentHint: 'Please don’t include personal data — the feedback is anonymous.',
+        send: 'Send feedback',
+        thanks: 'Thanks for the feedback!',
+        error: 'Could not send the feedback',
     },
 };
 


### PR DESCRIPTION
Stacked on #23 (chain: #16 → #17 → #20 → #21 → #22 → #23 → this). Retarget bases downward as parents merge.

## What it does
- After a volunteer submits the form, the confirmation screen offers a **1–5 star rating + optional comment** (localized NO/EN via #23's strings file, with an explicit "don't include personal data — this is anonymous" hint).
- Org admins get a **Tilbakemeldinger** tab: average rating, newest-first list, per-item delete.

## Privacy by construction
The feedback row carries **no identity**: no user id, no submission reference, no IP — only org, rating, comment, timestamp. It cannot be joined back to a person from server state, consistent with the platform's model.

## Plumbing
- One new table (`feedback`), added both as `scripts/migrations/2026-07-feedback.sql` (run in Hasura console + track the table) and to the fresh-install baseline. This is the first DB change since the baseline — deliberately small.
- API: anonymous `POST` behind a tight per-IP rate limit (5/10 min, stricter than the form's), admin `GET`/org-scoped `DELETE` behind the usual `requireOrgMemberBySlug` guard.

## Deploy note
Run the migration SQL and track `feedback` in the Hasura console before merging to production — the POST fails harmlessly (feedback error text on the confirmation screen, submission unaffected) if the table is missing.

## Verification
- Typecheck, lint, 108 unit tests, production build pass.
- 8/8 E2E pass, including a new test that walks form → confirmation → rate 4 stars → comment → send and asserts the exact API payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_