### PR TITLE
Review 9 — Docs: architecture map, development guide, roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,19 @@ This file exists so you don't accidentally "clean up" the things that
 make the system work. Read it before touching certificate verification,
 data retention, or the legacy `/verify` route.
 
+Companion docs (read as needed):
+
+- `docs/ARCHITECTURE.md` — system map: stack, data model, the three core
+  flows, security model, and things that look wrong but are deliberate.
+- `docs/DEVELOPMENT.md` — commands, verification checklist, conventions
+  (strings/i18n pattern, API route pattern, migrations workflow, test
+  placement), and the gotchas that have cost real time.
+- `docs/ROADMAP.md` — parked work with the reasoning captured, so options
+  don't get re-litigated or rebuilt by accident.
+
+Keep all four documents truthful in the SAME commit as any change that
+affects what they say.
+
 ## Security model: the hash IS the certificate
 
 The point of attester.no is to prove a certificate exists without storing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Admin-brukere kan logge inn for å godkjenne forespørsler, redigere maler og op
   Ingen personalia.
 
 Se [CLAUDE.md](CLAUDE.md) for personvernsmodellen og hvorfor det er
-viktig at strukturen forblir slik.
+viktig at strukturen forblir slik. Utfyllende dokumentasjon ligger i
+[docs/](docs/): arkitektur, utviklingsguide og roadmap.
 
 ## Struktur
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# Architecture
+
+A map of how attester.no fits together. For the privacy invariants that must
+never be broken, read [CLAUDE.md](../CLAUDE.md) first — this file explains
+*how* things work, that one explains *what must stay true*.
+
+## Stack
+
+| Layer | Technology | Notes |
+|---|---|---|
+| Frontend + API | Next.js 15 App Router, React 19, MUI 7 | Every route exports `runtime = 'edge'` |
+| Hosting | Cloudflare Pages via `@cloudflare/next-on-pages` | No Node APIs, no schedulers, no shared memory between isolates |
+| Database | Postgres via Hasura GraphQL (Nhost) | App talks to Hasura with the **admin secret**; tenancy is enforced in app code, NOT in Hasura permissions |
+| Auth | Nhost Auth (email/password) | JWT verified server-side with `jose` against remote JWKS |
+| PDF | pdfme 5, generated **client-side** in the admin's browser | Volunteer data never makes an extra server hop for rendering |
+
+## Core data model
+
+- `organizations` — identity only (id, slug, name). Never add content columns.
+- `user_organizations` — who administers which org. All members are equal.
+- `org_assets` — per-org content library keyed by `(organization_id, kind)`:
+  `signature`, `logo`, `body_text`, `lookup_list`. Images are base64 data URLs
+  inside the jsonb (known cost trade-off, see ROADMAP).
+- `templates` — **immutable** pdfme layouts + `form_schema` (the volunteer
+  form) + `field_bindings` (how each PDF field gets its value). Editing
+  creates a new row; certs reference the exact row they used.
+- `submissions` — transient volunteer data. Deleted by the retention sweep
+  24h after creation, no exceptions.
+- `certificates` — id, `submission_id` (opaque lookup key from the QR URL's
+  `id=` param — NOT a personal reference), `hash`, `template_id`,
+  `organization_id`, `issued_by`, `created_at`. Never anything personal.
+- `feedback` — anonymous rating + comment per org. No identity by design.
+- `invites` — 7-day tokens; redemption requires session email == invited email.
+- `legacy_certificates` — frozen pre-migration echo certs (until ~2030).
+
+## The three core flows
+
+### 1. Submit
+`/org/[slug]` → public form (schema from the org's default template) →
+`POST /api/org/[slug]/submissions` (rate-limited per IP, size-capped,
+template-ownership-checked) → row in `submissions` → optional content-free
+email to admins (`notify.ts`, Resend, opt-in via env).
+
+### 2. Issue
+Admin dashboard → "Generer PDF" → `submitHash` computes the canonical hash
+client-side (`src/util/canonicalHash.ts`) and `POST /api/org/[slug]/certificates`
+stores it (idempotent per submission; records `issued_by`). The PDF renders
+in the browser (`buildAttestPdfBlob`) with a QR pointing at
+`/org/[slug]/verify?t=<template>&id=<submission>&<fields...>`. The submission
+stays until its 24h TTL so the PDF can be regenerated; the retention sweep
+(`src/lib/server/retention.ts`) deletes it whenever the submissions API is
+next touched.
+
+### 3. Verify
+Anyone opens the QR URL → `OrgVerifyClient` recomputes the hash from the URL
+params (dropping `t`, sorting keys, SHA-512) and compares with the stored
+hash fetched by `submissionId`. Match ⇒ green. The database never learns what
+was attested; the URL carries the data.
+
+## Security model
+
+- **Server is the only boundary.** Client-side guards are UX, not security.
+- Every org-scoped route calls `requireOrgMemberBySlug` (`src/lib/server/apiAuth.ts`):
+  verify JWT → resolve slug → check `user_organizations`. Object ownership is
+  double-checked (`src/lib/server/ownership.ts`) when ids come from the client.
+- Platform-level actions (`/api/admin/*`) additionally require the caller's
+  `auth.users` email to be on the `PLATFORM_ADMIN_EMAILS` env allowlist
+  (`src/lib/server/platformAdmin.ts`). Unset ⇒ surface disabled.
+- Anonymous endpoints (submissions POST, feedback POST) are rate-limited
+  per IP (`src/lib/server/rateLimit.ts` — in-memory per isolate, best-effort)
+  and size-capped.
+- All Hasura access goes through `hasuraAdmin()` (`src/lib/server/hasura.ts`)
+  with GraphQL **variables only** — never interpolate values into query text.
+
+## Things that look wrong but are deliberate
+
+- Two verify routes (`/verify` legacy vs `/org/[slug]/verify`) that share no
+  code — printed QR codes froze the legacy contract. See CLAUDE.md.
+- `certificates.submission_id` survives submission deletion — it is the
+  verify lookup key, not a dangling personal reference.
+- The hash excludes `t` (template id) — presentation is not attested content.
+- No Hasura row-level permissions — tenancy lives in app code by design;
+  every new route MUST call the guards.
+- No cron anywhere — the retention sweep is lazy on purpose (edge runtime
+  has no scheduler; if nobody triggers the sweep, nobody is reading data).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,110 @@
+# Development guide
+
+Practical knowledge for working on this codebase — written for both humans
+and AI assistants. Read [CLAUDE.md](../CLAUDE.md) (invariants) and
+[ARCHITECTURE.md](ARCHITECTURE.md) (system map) before changing anything
+touching verification, retention, or auth.
+
+## Commands
+
+```bash
+npm install
+npm run dev          # local dev (needs .env.local, see .env.example)
+npm run typecheck    # tsc --noEmit
+npm run lint         # eslint — 2 known warnings are acceptable, 0 errors
+npm test             # vitest unit suite (src/**/*.test.ts only)
+npm run test:e2e     # Playwright suite (e2e/*.spec.ts), mocked APIs, no DB needed
+npm run build        # next build — needs NEXT_PUBLIC_NHOST_* set (placeholders fine)
+```
+
+Full verification before any commit:
+
+```bash
+rm -rf .next && npm run typecheck && npm run lint && npm test \
+  && NEXT_PUBLIC_NHOST_SUBDOMAIN=ci-placeholder NEXT_PUBLIC_NHOST_REGION=eu-central-1 npm run build \
+  && npm run test:e2e
+```
+
+CI (`.github/workflows/ci.yml`) runs exactly this on every push/PR.
+
+## Conventions
+
+### Strings & languages
+- Every user-facing string lives in `src/strings.ts`, in a `no` object and an
+  `en` object. `Strings = typeof no` makes missing translations a **compile
+  error** — never add a key to one language only.
+- Public pages (landing, /om, /personvern, form, verify, auth) read the
+  language from the URL: `?lang=en`, Norwegian default. Server components get
+  it from `searchParams`, client components from `useSearchParams()`.
+- Admin pages use `useAdminLang()` (`src/util/useAdminLang.ts`,
+  localStorage-persisted) and alias a subgroup:
+  `const a = strings.admin.<page>;`.
+- Interpolations are template functions in the dictionary:
+  `title: (org: string) => \`...\``.
+- Do NOT translate database-persisted values (asset names, template content,
+  starter template data) — only UI chrome.
+
+### API routes
+- Every route: `export const runtime = "edge";`.
+- Org-scoped admin routes start with
+  `const auth = await requireOrgMemberBySlug(req, slug); if (auth instanceof NextResponse) return auth;`.
+- Ids received from the client get an ownership check
+  (`templateBelongsToOrg`, `submissionBelongsToOrg`) before use.
+- Anonymous write endpoints get `checkRateLimit(...)` and explicit size caps.
+- Hasura: only through `hasuraAdmin<T>(query, variables)`. Values go in
+  variables, NEVER in the query string. Multiple root fields in one mutation
+  run in a single transaction — use that for atomicity (see the /admin org
+  creation for the client-generated-uuid trick).
+- Errors: `NextResponse.json({ error: message }, { status })`; catch and
+  return 500 with the message.
+
+### Database changes
+- Migrations are hand-run SQL in `scripts/migrations/`, executed in the
+  Hasura SQL console, then tables/columns must be (re-)tracked there.
+- Every new table/column goes in TWO places: a dated migration file AND
+  `0000-baseline-schema.sql` (which must stay a full, `IF NOT EXISTS`,
+  fresh-install script).
+- Think twice before any new table — the privacy model (CLAUDE.md) forbids
+  anything that stores volunteer fields outside `submissions`.
+
+### Tests
+- Unit tests: pure `.ts` modules only (vitest has no JSX transform). Put
+  logic in `src/util/` or `src/lib/server/` and test it there; keep React
+  components thin.
+- E2E: `e2e/*.spec.ts`, APIs mocked with `page.route()`. The verify tests
+  compute the SHA-512 independently (`e2e/helpers.ts`) — they are the guard
+  on the hash contract. MUI Rating gotcha: click
+  `.MuiRating-root label` (nth), not the hidden radio input.
+
+## Gotchas (each of these has cost real time)
+
+- **Stale `.next/types`** after switching branches breaks `tsc` with phantom
+  module errors → `rm -rf .next` first.
+- Scripts in `scripts/` without imports need `export {}` or their top-level
+  consts collide in tsc's global scope.
+- In sandboxes with a pre-provisioned Chromium, run e2e with
+  `PW_CHROMIUM_PATH=/opt/pw-browsers/chromium` instead of `playwright install`.
+- `.claude/` is gitignored (AI worktrees live there) — keep it that way.
+- The edge runtime has no `setInterval`/cron, no Node `crypto` module (use
+  Web Crypto), and per-isolate memory only.
+- `next-env.d.ts` is generated and lint-ignored; don't edit or lint it.
+
+## Deploy checklist (per release)
+
+1. Merge to `main`; `npm run deploy` (wrangler → Cloudflare Pages) or CI/CD.
+2. Run any new `scripts/migrations/*.sql` in the Hasura console and (re-)track
+   affected tables.
+3. Env vars live in Cloudflare Pages: `NEXT_PUBLIC_NHOST_*`,
+   `NHOST_ADMIN_SECRET`, `NHOST_JWT_SECRET`, optional `PLATFORM_ADMIN_EMAILS`,
+   `RESEND_API_KEY`, `NOTIFY_EMAIL_FROM`.
+4. One-time Nhost setup: production URL + `/login/reset` in Auth → Redirect URLs.
+
+## Working style that has worked here
+
+- Small, independently shippable slices; stacked PRs when they depend on each
+  other (base each PR on its parent branch, retarget to main as parents merge).
+- Group changes by review difficulty: language/tests/UI polish are quick
+  approvals; anything touching issuance, retention, auth, or tenancy gets its
+  own clearly-labelled PR for deep review.
+- Update CLAUDE.md in the same commit as any change to an invariant it
+  documents. Stale invariant docs are worse than none.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,65 @@
+# Roadmap
+
+Deliberate future work, with the reasoning captured so it doesn't have to be
+re-derived. Items are parked, not forgotten — each says what unblocks it.
+
+## Near-term (unblocked, just needs doing)
+
+- **Translate the template designer and content library** (`edit_pdf/*`,
+  `rediger/page.tsx`, ~1 800 lines). The pattern is established
+  (`src/strings.ts` + `useAdminLang`); every other admin page is done.
+  Only UI chrome — never database-persisted values.
+- **Live end-to-end pass against real Nhost** before onboarding a stranger
+  org: password reset email, signup (check whether email verification is on),
+  invite redemption, issue + verify one attest on paper, confirm the sweep
+  deletes an expired submission.
+- **Pilot**: echo + one external org through the full lifecycle.
+
+## Needs a decision or an account (owner: the human)
+
+- **Error tracking** — the most important gap once strangers depend on the
+  product; today production failures are invisible (`console.error` only).
+  Sentry or Cloudflare-native. Do this before promoting beyond people you know.
+- **Email provider** — `RESEND_API_KEY`/`NOTIFY_EMAIL_FROM` enable submission
+  notifications and invite emails (both already ship dark without it). A short
+  TTL is only comfortable with notifications on.
+- **`hei@attester.no`** — referenced in the help dialog, /om, and
+  /personvern. Must actually exist.
+- **Privacy policy substance** — /personvern was drafted faithfully to the
+  architecture, but it is a commitment; the controller framing and contact
+  details need the owner's sign-off.
+
+## Design options captured (build when the need is real)
+
+- **24h-after-issuance regeneration window.** Today the window runs from
+  *submission* (one `SUBMISSION_TTL_HOURS` constant); a submission issued at
+  hour 23 has 1h of regeneration left. If orgs hit this, switch the sweep to
+  an explicit `expires_at` column (set at creation, bumped at issuance) —
+  small migration + sweep change. Decided against preemptively (2026-07-12).
+- **Hash algorithm v2 escape hatch.** Documented in CLAUDE.md ("version-tag
+  the hash"). Not implemented on purpose; the dispatch costs nothing until
+  actually needed.
+- **Cert revocation.** Would need a `revoked_at` column + verify-path check
+  + admin UI + policy decisions (who may revoke, is it visible publicly).
+  Nothing stores personal data, so revocation is purely a trust feature.
+- **Durable rate limiting** (Cloudflare KV/DO) if the per-isolate limiter
+  proves too soft at real scale. The seam is one function
+  (`checkRateLimit`).
+- **Media out of Postgres.** Logos/signatures are base64 in `org_assets`
+  jsonb — fine at pilot scale, a cost/perf smell as orgs multiply. Move to
+  Nhost Storage; the seam is `ImageUpload.tsx` + `resolveBinding`'s asset
+  sub-field reads.
+- **i18n beyond NO/EN** — the strings file scales to more languages
+  mechanically, but wait for actual demand.
+- **Dedicated backend** — evaluated 2026-07-12 and rejected for now: Hasura
+  is a thin data pipe, authz lives in app code, and the clean seams
+  (`hasuraAdmin`, `lib/server` guards) keep an incremental migration cheap if
+  server-side PDF generation, queues, or websockets ever become requirements.
+  Protect those seams.
+
+## Explicitly frozen
+
+- The legacy `/verify` route and everything listed under it in CLAUDE.md —
+  untouched until ~2030.
+- The v1 canonical-hash contract (`src/util/canonicalHash.ts` +
+  `certParams.ts`) — any change invalidates printed certificates.


### PR DESCRIPTION
Stacked on #32 (part 9 of the review stack). Documentation only — easy approve, and specifically written so **future AI-assisted development** starts with full context instead of re-deriving it:

- **`docs/ARCHITECTURE.md`** — stack, data model, the three core flows (submit/issue/verify), the security model, and a "things that look wrong but are deliberate" section (two verify routes, `submission_id` on certs, hash excluding `t`, no Hasura permissions, no cron).
- **`docs/DEVELOPMENT.md`** — commands, the exact verification checklist CI runs, the conventions every PR in this stack follows (strings/i18n pattern, API route pattern, migrations-in-two-places rule, pure-module test placement), and the gotchas that have cost real time (stale `.next/types`, `export {}` in scripts, `PW_CHROMIUM_PATH`, MUI Rating in e2e).
- **`docs/ROADMAP.md`** — parked work *with the reasoning captured*: the 24h-from-issuance window option, hash-v2 hatch, revocation, media storage, the dedicated-backend evaluation and why it was rejected for now.

CLAUDE.md points at all three and mandates keeping the docs truthful in the same commit as any invariant change. README links `docs/`.

Verification: typecheck + lint pass (content-only change otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_