### PR TITLE
Review 11 — Hardening: DB-enforced cert uniqueness, race-safe issuance, token validation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,10 +5,6 @@ re-derived. Items are parked, not forgotten — each says what unblocks it.
 
 ## Near-term (unblocked, just needs doing)
 
-- **Translate the template designer and content library** (`edit_pdf/*`,
-  `rediger/page.tsx`, ~1 800 lines). The pattern is established
-  (`src/strings.ts` + `useAdminLang`); every other admin page is done.
-  Only UI chrome — never database-persisted values.
 - **Live end-to-end pass against real Nhost** before onboarding a stranger
   org: password reset email, signup (check whether email verification is on),
   invite redemption, issue + verify one attest on paper, confirm the sweep

--- a/scripts/migrations/0000-baseline-schema.sql
+++ b/scripts/migrations/0000-baseline-schema.sql
@@ -70,9 +70,9 @@ CREATE TABLE IF NOT EXISTS org_assets (
 CREATE INDEX IF NOT EXISTS org_assets_org_idx ON org_assets(organization_id);
 CREATE INDEX IF NOT EXISTS org_assets_kind_idx ON org_assets(organization_id, kind);
 
--- Volunteer form submissions. Deleted automatically in the same
--- transaction that inserts the certificate — rows here are transient
--- review-queue state, never long-term storage.
+-- Volunteer form submissions. Deleted automatically by the retention
+-- sweep 24 hours after creation (issued or not) — rows here are
+-- transient review-queue state, never long-term storage.
 CREATE TABLE IF NOT EXISTS submissions (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
@@ -85,8 +85,8 @@ CREATE INDEX IF NOT EXISTS submissions_template_idx ON submissions(template_id);
 
 -- The hash IS the certificate: no volunteer fields, ever (see CLAUDE.md).
 -- submission_id is the opaque lookup key embedded in the QR URL's `id`
--- param (a submissions uuid stored as text; the submission row itself is
--- deleted at issuance). template_id is SET NULL on template deletion —
+-- param (a submissions uuid stored as text; the submission row itself
+-- expires on its 24h TTL). template_id is SET NULL on template deletion —
 -- the hash keeps verifying regardless of presentation.
 CREATE TABLE IF NOT EXISTS certificates (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -97,7 +97,8 @@ CREATE TABLE IF NOT EXISTS certificates (
     issued_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
     created_at timestamptz NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS certificates_lookup_idx ON certificates(organization_id, submission_id);
+CREATE UNIQUE INDEX IF NOT EXISTS certificates_org_submission_unique
+    ON certificates(organization_id, submission_id);
 
 -- One-time snapshot of echo's pre-migration certs. The app NEVER inserts
 -- here; the legacy /verify route reads it until ~2030 (see CLAUDE.md).

--- a/scripts/migrations/2026-07-cert-unique.sql
+++ b/scripts/migrations/2026-07-cert-unique.sql
@@ -1,0 +1,19 @@
+-- Backstop for certificate idempotency: at most ONE cert per submission
+-- per org, enforced by the database instead of only by the API's
+-- check-then-insert (which has a small race window under concurrent
+-- clicks). The API treats a violation as "already issued" and returns
+-- the existing row.
+--
+-- BEFORE running: check for pre-existing duplicates (possible from the
+-- era before the idempotent POST). If this returns rows, keep the oldest
+-- of each group and delete the rest — they carry identical hashes:
+--
+--   SELECT organization_id, submission_id, COUNT(*)
+--   FROM certificates
+--   GROUP BY organization_id, submission_id
+--   HAVING COUNT(*) > 1;
+--
+-- Run in the Hasura SQL console. No re-tracking needed (index only).
+
+CREATE UNIQUE INDEX IF NOT EXISTS certificates_org_submission_unique
+    ON certificates(organization_id, submission_id);

--- a/src/app/api/invites/redeem/route.ts
+++ b/src/app/api/invites/redeem/route.ts
@@ -23,8 +23,11 @@ export async function POST(req: NextRequest) {
     if (session instanceof NextResponse) return session;
 
     const { token } = await req.json().catch(() => ({} as { token?: unknown }));
-    if (typeof token !== "string" || !token) {
-        return NextResponse.json({ error: "Missing token" }, { status: 400 });
+    // The token variable is typed uuid! in the GraphQL query — validate the
+    // shape here so a malformed token is a clean 404, not a Hasura error.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (typeof token !== "string" || !UUID_RE.test(token)) {
+        return NextResponse.json({ error: "Invitasjonen er ugyldig eller utløpt" }, { status: 404 });
     }
 
     try {

--- a/src/app/api/org/[slug]/certificates/route.ts
+++ b/src/app/api/org/[slug]/certificates/route.ts
@@ -108,19 +108,40 @@ export async function POST(
             return NextResponse.json({ id: existing.certificates[0].id, alreadyIssued: true });
         }
 
-        const data = await hasuraAdmin<{ insert_certificates_one: { id: string } }>(
-            `mutation InsertCertificate($organizationId: uuid!, $submissionId: String!, $hash: String!, $templateId: uuid!, $issuedBy: uuid!) {
-                insert_certificates_one(object: {
-                    organization_id: $organizationId,
-                    submission_id: $submissionId,
-                    hash: $hash,
-                    template_id: $templateId,
-                    issued_by: $issuedBy
-                }) { id }
-            }`,
-            { organizationId: auth.organizationId, submissionId, hash, templateId, issuedBy: auth.userId },
-        );
-        return NextResponse.json({ id: data.insert_certificates_one.id });
+        try {
+            const data = await hasuraAdmin<{ insert_certificates_one: { id: string } }>(
+                `mutation InsertCertificate($organizationId: uuid!, $submissionId: String!, $hash: String!, $templateId: uuid!, $issuedBy: uuid!) {
+                    insert_certificates_one(object: {
+                        organization_id: $organizationId,
+                        submission_id: $submissionId,
+                        hash: $hash,
+                        template_id: $templateId,
+                        issued_by: $issuedBy
+                    }) { id }
+                }`,
+                { organizationId: auth.organizationId, submissionId, hash, templateId, issuedBy: auth.userId },
+            );
+            return NextResponse.json({ id: data.insert_certificates_one.id });
+        } catch (e) {
+            // Concurrent double-click race: the unique index on
+            // (organization_id, submission_id) rejects the second insert.
+            // Re-read and return the winner — same data, same hash.
+            if ((e as Error).message.includes('certificates_org_submission_unique')) {
+                const winner = await hasuraAdmin<{ certificates: Array<{ id: string }> }>(
+                    `query ExistingCert($submissionId: String!, $organizationId: uuid!) {
+                        certificates(where: {
+                            submission_id: { _eq: $submissionId },
+                            organization_id: { _eq: $organizationId }
+                        }, limit: 1) { id }
+                    }`,
+                    { submissionId, organizationId: auth.organizationId },
+                );
+                if (winner.certificates.length > 0) {
+                    return NextResponse.json({ id: winner.certificates[0].id, alreadyIssued: true });
+                }
+            }
+            throw e;
+        }
     } catch (e) {
         return NextResponse.json({ error: (e as Error).message }, { status: 500 });
     }


### PR DESCRIPTION
Stacked on #34 (part 11, the top of the review stack). Small, security-relevant — review alongside #29/#32.

Outcome of an inline security pass over every new attack surface (auth guards, invites, platform admin, feedback, branding, issuance, retention, rate limiting). Two things warranted code; the rest checked out clean — full notes posted on #29.

- **DB-enforced idempotency**: unique index on `certificates(organization_id, submission_id)` (`2026-07-cert-unique.sql` + baseline). The cert POST's check-then-insert had a small race window under concurrent double-clicks; now the database rejects the second insert and the API catches it and returns the winning row (`alreadyIssued: true`) instead of erroring. **Before running the migration**: the file includes a query to check for pre-idempotency duplicate rows; dedupe first if it returns anything.
- **Invite token shape validation**: a malformed (non-UUID) token now returns a clean 404 instead of a Hasura type error surfacing as a 500.
- Baseline schema comments updated to the 24h-TTL model (they still described delete-at-issuance); ROADMAP drops the completed designer-translation item.

Verification: typecheck, lint, 110 unit tests, production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_