### PR TITLE
Review 12 — SEO: sitemap, canonical/hreflang, structured data, keyword metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Companion docs (read as needed):
   placement), and the gotchas that have cost real time.
 - `docs/ROADMAP.md` — parked work with the reasoning captured, so options
   don't get re-litigated or rebuilt by accident.
+- `docs/SEO.md` — search strategy: what shipped in code, and the
+  owner actions (Search Console, backlinks) that actually move rankings.
 
 Keep all four documents truthful in the SAME commit as any change that
 affects what they say.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,9 @@ re-derived. Items are parked, not forgotten — each says what unblocks it.
 
 ## Needs a decision or an account (owner: the human)
 
+- **SEO owner actions** — Search Console/Bing verification, sitemap
+  submission, backlinks from member orgs. Full playbook: docs/SEO.md.
+
 - **Error tracking** — the most important gap once strangers depend on the
   product; today production failures are invisible (`console.error` only).
   Sentry or Cloudflare-native. Do this before promoting beyond people you know.

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -1,0 +1,82 @@
+# SEO playbook
+
+How attester.no gets found for searches like «attest frivillig arbeid»,
+«frivillighetsattest» and «attest mal frivillig organisasjon». Half of this
+is code (shipped, see below); the other half is actions only the owner can
+take — do those, they matter more.
+
+## What the research showed (July 2026)
+
+Searching the obvious Norwegian queries surfaces **no product** — only
+generic guidance and one downloadable Word template:
+
+- Frivillighet Norge's formalities pages (politiattest guidance, not
+  attest issuance): https://www.frivillighetnorge.no/verktoy/ha-det-formelle-i-orden/politiattester/
+- frivillig.no's FAQ pages about volunteering generally:
+  https://om.frivillig.no/faq-om-frivillighet-og-frivilligno
+- Arbeidstilsynet on frivillig arbeid (legal/employment angle):
+  https://www.arbeidstilsynet.no/lonn-og-ansettelse/ansettelse/frivillig-arbeid/
+- Diabetesforbundet's `.doc` attest template — literally a Word file:
+  https://www.diabetes.no/globalassets/min-side/for-tillitsvalgte/skjema-og-maler/attest-for-tillitsvalgte/attestforfrivilligarbeid.doc
+
+Conclusion: the niche is winnable. People searching these terms are org
+admins looking for a **template or a process** — exactly what this product
+replaces. Low competition means on-page correctness + a handful of relevant
+backlinks can rank; there is no incumbent to displace.
+
+## Shipped in code (this PR)
+
+- `sitemap.xml` (app/sitemap.ts): static pages + every public org form,
+  resilient to DB outage. `robots.txt` references it and now also blocks
+  `/admin`.
+- Canonical URLs + `hreflang` (nb-NO / en / x-default) on `/`, `/om`,
+  `/personvern` via `publicPageMetadata` (`src/util/seo.ts`) — the `?lang=en`
+  variants are declared alternates, not duplicate content.
+- `metadataBase`, Open Graph and Twitter-card defaults; keyword-informed
+  site title («digital attest for frivillige») and meta description
+  containing the money phrases.
+- Structured data (`src/components/JsonLd.tsx`): `WebSite` on the landing
+  page, `FAQPage` on `/om` (built from the strings file, so it stays in
+  sync with the visible content in both languages) — eligible for FAQ rich
+  results.
+- Already in place from earlier work and load-bearing for SEO: real
+  server-rendered content on `/`, `/om`, `/personvern`; per-org page
+  titles; `lang="no"`; fast edge rendering.
+
+## Owner actions (in priority order — these move the needle most)
+
+1. **Google Search Console + Bing Webmaster Tools**: verify the domain,
+   submit `https://attester.no/sitemap.xml`, request indexing of `/`,
+   `/om`, `/personvern`. This is the difference between "indexed this
+   week" and "indexed whenever". Bing also feeds DuckDuckGo.
+2. **Backlinks from member orgs**: every org using the platform should
+   link their `/org/<slug>` page from their own site ("Be om attest").
+   echo's site is the first. These are topically perfect links.
+   Note: every issued PDF already carries "Verifiser på attester.no" —
+   physical-world brand distribution comes free with usage.
+3. **Get listed where orgs look**: Frivillighet Norge's verktøy pages,
+   studentorganisasjon resource lists, ungdomsorganisasjon networks
+   (LNU). One relevant directory link beats ten random ones.
+4. **A content page that answers the template query directly** (future PR
+   idea, high value): «Mal for attest til frivillige» — an article page
+   with a worked example of what a good attest contains, that naturally
+   ends in "or issue verifiable ones with attester.no". This targets the
+   single most obvious query in the niche (people searching for the
+   Diabetesforbundet-style .doc).
+5. **Keep URLs stable.** Rankings accrue to URLs; don't rename `/om` or
+   `/personvern` later without redirects.
+
+## What NOT to do
+
+- No keyword stuffing beyond what shipped — the copy reads naturally and
+  must stay that way.
+- No paid link schemes; the niche is small enough that legitimacy wins.
+- Don't index the admin or verify URLs (verify URLs carry personal data in
+  the query string — they're deliberately unlinked, and robots keeps admin
+  surfaces out).
+
+## Measuring
+
+Search Console's "Performance" tab is the scoreboard: impressions for the
+target queries should appear within weeks of submission, clicks follow
+content + backlinks. Revisit this file when the first pilot org is live.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,32 @@
+import type { Metadata } from 'next';
 import RootLayoutProvider from '@/app/style/rootLayout';
 import {Suspense} from "react";
+import { SITE_URL } from '@/util/seo';
 
-export const metadata = {
+export const metadata: Metadata = {
+    metadataBase: new URL(SITE_URL),
     title: {
-        default: 'attester.no',
+        default: 'attester.no – digital attest for frivillige',
         template: '%s – attester.no',
     },
-    description: 'Digitalt verifiserbare attester for frivillige – uten at personopplysninger lagres.',
+    description: 'Lag, utsted og verifiser attester for frivillig arbeid. Digital frivillighetsattest med QR-kode – uten at personopplysninger lagres.',
+    keywords: [
+        'attest frivillig arbeid',
+        'frivillighetsattest',
+        'attest mal frivillig organisasjon',
+        'digital attest',
+        'verifiserbar attest',
+        'attest med QR-kode',
+        'volunteer certificate',
+    ],
+    openGraph: {
+        siteName: 'attester.no',
+        type: 'website',
+        locale: 'nb_NO',
+    },
+    twitter: {
+        card: 'summary',
+    },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/src/app/om/page.tsx
+++ b/src/app/om/page.tsx
@@ -4,6 +4,8 @@ import {
 } from '@mui/material';
 import { getStrings } from '@/strings';
 import LanguageToggle from '@/components/LanguageToggle';
+import JsonLd from '@/components/JsonLd';
+import { publicPageMetadata } from '@/util/seo';
 
 export const runtime = 'edge';
 
@@ -13,7 +15,8 @@ export async function generateMetadata({
     searchParams: Promise<{ lang?: string }>;
 }) {
     const { lang } = await searchParams;
-    return { title: getStrings(lang).about.metaTitle };
+    const s = getStrings(lang).about;
+    return publicPageMetadata('/om', lang, s.metaTitle, s.intro);
 }
 
 export default async function AboutPage({
@@ -25,8 +28,26 @@ export default async function AboutPage({
     const s = getStrings(lang).about;
     const withLang = (path: string) => (lang === 'en' ? `${path}?lang=en` : path);
 
+    const faq = [
+        { q: s.flowTitle, a: s.flowSteps.join(' ') },
+        { q: s.storedTitle, a: `${s.storedIntro} ${s.storedItems.join('; ')}. ${s.neverStoredIntro} ${s.neverStoredItems.join('; ')}.` },
+        { q: s.hashTitle, a: `${s.hashBody} ${s.hashConsequence}` },
+        { q: s.verifyTitle, a: s.verifySteps.join(' ') },
+    ];
+
     return (
         <Container maxWidth="md" sx={{ py: 6 }}>
+            <JsonLd
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'FAQPage',
+                    mainEntity: faq.map((f) => ({
+                        '@type': 'Question',
+                        name: f.q,
+                        acceptedAnswer: { '@type': 'Answer', text: f.a },
+                    })),
+                }}
+            />
             <Stack spacing={4}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 2 }}>
                     <Typography variant="h3" component="h1">{s.title}</Typography>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,19 @@ import {
 import { listPublicOrgs, type PublicOrg } from '@/lib/server/orgs';
 import { getStrings } from '@/strings';
 import LanguageToggle from '@/components/LanguageToggle';
+import JsonLd from '@/components/JsonLd';
+import { publicPageMetadata, SITE_URL } from '@/util/seo';
 
 export const runtime = 'edge';
+
+export async function generateMetadata({
+    searchParams,
+}: {
+    searchParams: Promise<{ lang?: string }>;
+}) {
+    const { lang } = await searchParams;
+    return publicPageMetadata('/', lang, undefined, getStrings(lang).landing.tagline);
+}
 
 export default async function Home({
     searchParams,
@@ -27,6 +38,16 @@ export default async function Home({
 
     return (
         <Container maxWidth="md" sx={{ py: 8 }}>
+            <JsonLd
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'WebSite',
+                    name: 'attester.no',
+                    url: SITE_URL,
+                    description: s.tagline,
+                    inLanguage: ['nb-NO', 'en'],
+                }}
+            />
             <Stack spacing={6}>
                 <Box>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 2 }}>

--- a/src/app/personvern/page.tsx
+++ b/src/app/personvern/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Box, Container, Divider, Stack, Typography } from '@mui/material';
 import { getStrings } from '@/strings';
 import LanguageToggle from '@/components/LanguageToggle';
+import { publicPageMetadata } from '@/util/seo';
 
 export const runtime = 'edge';
 
@@ -11,7 +12,8 @@ export async function generateMetadata({
     searchParams: Promise<{ lang?: string }>;
 }) {
     const { lang } = await searchParams;
-    return { title: getStrings(lang).privacy.metaTitle };
+    const s = getStrings(lang).privacy;
+    return publicPageMetadata('/personvern', lang, s.metaTitle, s.sections[1]?.body ?? s.title);
 }
 
 export default async function PrivacyPage({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/util/seo';
 
 export default function robots(): MetadataRoute.Robots {
     return {
@@ -9,8 +10,9 @@ export default function robots(): MetadataRoute.Robots {
                 // Admin and API surfaces have no business in search indexes.
                 // Verify pages stay crawlable-in-principle but are unlinked
                 // and unguessable (the URL is the secret).
-                disallow: ['/login', '/api'],
+                disallow: ['/login', '/api', '/admin'],
             },
         ],
+        sitemap: `${SITE_URL}/sitemap.xml`,
     };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+import { listPublicOrgs } from '@/lib/server/orgs';
+import { SITE_URL } from '@/util/seo';
+
+export const runtime = 'edge';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const statics: MetadataRoute.Sitemap = [
+        { url: `${SITE_URL}/`, changeFrequency: 'weekly', priority: 1 },
+        { url: `${SITE_URL}/om`, changeFrequency: 'monthly', priority: 0.9 },
+        { url: `${SITE_URL}/personvern`, changeFrequency: 'monthly', priority: 0.5 },
+    ];
+
+    // Org form pages are public entry points; the sitemap must still render
+    // if the database is unreachable.
+    let orgPages: MetadataRoute.Sitemap = [];
+    try {
+        orgPages = (await listPublicOrgs()).map((org) => ({
+            url: `${SITE_URL}/org/${encodeURIComponent(org.slug)}`,
+            changeFrequency: 'weekly' as const,
+            priority: 0.7,
+        }));
+    } catch {
+        // directory unavailable — ship the static pages
+    }
+
+    return [...statics, ...orgPages];
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Renders schema.org structured data. The payload is always built from our
+ * own dictionary strings — never from user input — so serializing it into
+ * a script tag is safe.
+ */
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        />
+    );
+}

--- a/src/util/seo.ts
+++ b/src/util/seo.ts
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+export const SITE_URL = 'https://attester.no';
+
+/**
+ * Canonical + hreflang metadata for the public pages. Norwegian is the
+ * canonical language; the English variant lives at ?lang=en. Search
+ * engines get told both exist so neither is treated as duplicate content.
+ */
+export function publicPageMetadata(
+    path: string,
+    lang: string | null | undefined,
+    title: string | undefined,
+    description: string,
+): Metadata {
+    const canonical = `${SITE_URL}${path}`;
+    return {
+        ...(title ? { title } : {}),
+        description,
+        alternates: {
+            canonical,
+            languages: {
+                'nb-NO': canonical,
+                en: `${canonical}?lang=en`,
+                'x-default': canonical,
+            },
+        },
+        openGraph: {
+            title: title ?? 'attester.no',
+            description,
+            url: canonical,
+            siteName: 'attester.no',
+            locale: lang === 'en' ? 'en_US' : 'nb_NO',
+            type: 'website',
+        },
+    };
+}


### PR DESCRIPTION
Stacked on #35 (part 12, top of the review stack). On-page SEO + a written playbook for the off-page half.

## Why this is worth doing now
Research on the target queries («attest frivillig arbeid mal», «frivillighetsattest», «attest mal frivillig organisasjon») shows the SERP is generic guidance (Frivillighet Norge, Arbeidstilsynet, frivillig.no) plus **one downloadable Word template** — no product owns the niche. Low competition means correct on-page work + a few topically-perfect backlinks can rank. Full findings with links in `docs/SEO.md`.

## Shipped
- **`sitemap.xml`** (static pages + every public org form, DB-outage safe); **`robots.txt`** now references it and blocks `/admin` (the follow-up noted back in the phase PRs).
- **Canonical + hreflang** (`nb-NO` / `en` / `x-default`) on `/`, `/om`, `/personvern` via a shared `publicPageMetadata` helper — the `?lang=en` variants are declared alternates, not duplicate content. Verified rendering: `<link rel="canonical">` + three alternates in the head.
- **`metadataBase`**, Open Graph and Twitter defaults; keyword-informed site title («attester.no – digital attest for frivillige») and meta description carrying the money phrases naturally.
- **Structured data**: `WebSite` on the landing page; `FAQPage` on `/om`, built from the strings file so it tracks the visible content in both languages (eligible for FAQ rich results).
- **`docs/SEO.md`**: the research, what shipped, and the prioritized owner playbook.

## The half only you can do (from docs/SEO.md, in priority order)
1. **Google Search Console + Bing Webmaster**: verify the domain, submit the sitemap, request indexing — the difference between indexed-this-week and indexed-eventually.
2. **Backlinks from member orgs** — every org links their `/org/<slug>` page from their own site; echo first. (Every printed PDF already advertises attester.no.)
3. **Directory listings** where org admins actually look: Frivillighet Norge verktøy, student/ungdomsorg networks.
4. Future content PR idea (highest-value query): a «Mal for attest til frivillige» article page targeting the people currently downloading that .doc.

## Verification
Typecheck, lint, 110 unit tests, 8 E2E, production build; robots/sitemap/JSON-LD/hreflang all smoke-verified on a dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_