### PR TITLE
Design pass — public pages: theme, shared shell, landing rework

### DIFF
--- a/src/app/om/page.tsx
+++ b/src/app/om/page.tsx
@@ -3,7 +3,7 @@ import {
     Box, Container, Divider, Grid, Paper, Stack, Typography,
 } from '@mui/material';
 import { getStrings } from '@/strings';
-import LanguageToggle from '@/components/LanguageToggle';
+import PublicShell from '@/components/PublicShell';
 import JsonLd from '@/components/JsonLd';
 import { publicPageMetadata } from '@/util/seo';
 
@@ -36,6 +36,7 @@ export default async function AboutPage({
     ];
 
     return (
+        <PublicShell lang={lang}>
         <Container maxWidth="md" sx={{ py: 6 }}>
             <JsonLd
                 data={{
@@ -49,10 +50,7 @@ export default async function AboutPage({
                 }}
             />
             <Stack spacing={4}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 2 }}>
-                    <Typography variant="h3" component="h1">{s.title}</Typography>
-                    <LanguageToggle />
-                </Box>
+                <Typography variant="h3" component="h1">{s.title}</Typography>
 
                 <Typography variant="h6" component="p" color="text.secondary">
                     {s.intro}
@@ -120,5 +118,6 @@ export default async function AboutPage({
                 </Box>
             </Stack>
         </Container>
+        </PublicShell>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link';
 import {
-    Box, Button, Chip, Container, Divider, Paper, Stack, Typography,
+    Box, Chip, Container, Paper, Stack, Typography,
 } from '@mui/material';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { listPublicOrgs, type PublicOrg } from '@/lib/server/orgs';
 import { getStrings } from '@/strings';
-import LanguageToggle from '@/components/LanguageToggle';
+import PublicShell from '@/components/PublicShell';
 import JsonLd from '@/components/JsonLd';
 import { publicPageMetadata, SITE_URL } from '@/util/seo';
 
@@ -37,7 +38,7 @@ export default async function Home({
     }
 
     return (
-        <Container maxWidth="md" sx={{ py: 8 }}>
+        <PublicShell lang={lang}>
             <JsonLd
                 data={{
                     '@context': 'https://schema.org',
@@ -48,65 +49,108 @@ export default async function Home({
                     inLanguage: ['nb-NO', 'en'],
                 }}
             />
-            <Stack spacing={6}>
-                <Box>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 2 }}>
-                        <Typography variant="h2" component="h1" gutterBottom>
-                            attester.no
-                        </Typography>
-                        <LanguageToggle />
-                    </Box>
-                    <Typography variant="h5" color="text.secondary">
+
+            {/* Hero */}
+            <Box sx={{ bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}>
+                <Container maxWidth="md" sx={{ py: { xs: 8, md: 12 }, textAlign: 'center' }}>
+                    <Typography variant="h2" component="h1" gutterBottom>
+                        attester
+                        <Box component="span" sx={{ color: 'primary.main' }}>.no</Box>
+                    </Typography>
+                    <Typography
+                        variant="h5"
+                        component="p"
+                        color="text.secondary"
+                        sx={{ maxWidth: 620, mx: 'auto', lineHeight: 1.5 }}
+                    >
                         {s.tagline}
                     </Typography>
-                </Box>
+                </Container>
+            </Box>
 
-                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-                    {s.steps.map((step) => (
-                        <Paper key={step.title} elevation={2} sx={{ p: 3, flex: 1 }}>
-                            <Typography variant="h6" gutterBottom>{step.title}</Typography>
-                            <Typography variant="body2" color="text.secondary">{step.text}</Typography>
-                        </Paper>
-                    ))}
-                </Stack>
+            <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
+                <Stack spacing={{ xs: 6, md: 8 }}>
+                    {/* The three steps */}
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2.5}>
+                        {s.steps.map((step, i) => (
+                            <Paper
+                                key={step.title}
+                                variant="outlined"
+                                sx={{ p: 3, flex: 1, bgcolor: 'background.paper' }}
+                            >
+                                <Box
+                                    sx={{
+                                        width: 36,
+                                        height: 36,
+                                        borderRadius: '50%',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        bgcolor: 'primary.main',
+                                        color: 'primary.contrastText',
+                                        fontWeight: 700,
+                                        mb: 2,
+                                    }}
+                                >
+                                    {i + 1}
+                                </Box>
+                                <Typography variant="subtitle1" gutterBottom>
+                                    {step.title.replace(/^\d+\.\s*/, '')}
+                                </Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    {step.text}
+                                </Typography>
+                            </Paper>
+                        ))}
+                    </Stack>
 
-                <Paper elevation={0} sx={{ p: 3, bgcolor: 'grey.50' }}>
-                    <Typography variant="h6" gutterBottom>{s.privacyTitle}</Typography>
-                    <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
-                        {s.privacyBody}
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
-                        <Link href={withLang('/om')}>{s.aboutLink}</Link>
-                        <Link href={withLang('/personvern')}>{s.privacyLink}</Link>
-                    </Box>
-                </Paper>
-
-                {orgs.length > 0 && (
-                    <Box>
-                        <Typography variant="h6" gutterBottom>{s.orgsTitle}</Typography>
-                        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                            {s.orgsSubtitle}
+                    {/* Privacy card */}
+                    <Paper
+                        variant="outlined"
+                        sx={{
+                            p: { xs: 3, md: 4 },
+                            borderLeft: 4,
+                            borderLeftColor: 'primary.main',
+                            bgcolor: 'background.paper',
+                        }}
+                    >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+                            <ShieldOutlinedIcon color="primary" />
+                            <Typography variant="h6" component="h2">{s.privacyTitle}</Typography>
+                        </Box>
+                        <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+                            {s.privacyBody}
                         </Typography>
-                        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-                            {orgs.map((org) => (
-                                <Chip
-                                    key={org.slug}
-                                    label={org.name}
-                                    component={Link}
-                                    href={withLang(`/org/${encodeURIComponent(org.slug)}`)}
-                                    clickable
-                                />
-                            ))}
-                        </Stack>
-                    </Box>
-                )}
+                        <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', fontSize: '0.9rem' }}>
+                            <Link href={withLang('/om')}>{s.aboutLink}</Link>
+                            <Link href={withLang('/personvern')}>{s.privacyLink}</Link>
+                        </Box>
+                    </Paper>
 
-                <Divider />
+                    {/* Org directory */}
+                    {orgs.length > 0 && (
+                        <Box>
+                            <Typography variant="h6" component="h2" gutterBottom>{s.orgsTitle}</Typography>
+                            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                                {s.orgsSubtitle}
+                            </Typography>
+                            <Stack direction="row" spacing={1.5} useFlexGap flexWrap="wrap">
+                                {orgs.map((org) => (
+                                    <Chip
+                                        key={org.slug}
+                                        label={org.name}
+                                        component={Link}
+                                        href={withLang(`/org/${encodeURIComponent(org.slug)}`)}
+                                        clickable
+                                        variant="outlined"
+                                        sx={{ px: 0.5, py: 2.25, fontSize: '0.9rem' }}
+                                    />
+                                ))}
+                            </Stack>
+                        </Box>
+                    )}
 
-                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
-                    <Button component={Link} href="/login" variant="outlined">
-                        {s.adminLogin}
-                    </Button>
+                    {/* Contact prompt */}
                     <Typography variant="body2" color="text.secondary">
                         {s.contactPrompt}{' '}
                         <Link href="https://github.com/ArneeMe/attester.no" target="_blank" rel="noreferrer">
@@ -114,7 +158,7 @@ export default async function Home({
                         </Link>.
                     </Typography>
                 </Stack>
-            </Stack>
-        </Container>
+            </Container>
+        </PublicShell>
     );
 }

--- a/src/app/personvern/page.tsx
+++ b/src/app/personvern/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Box, Container, Divider, Stack, Typography } from '@mui/material';
 import { getStrings } from '@/strings';
-import LanguageToggle from '@/components/LanguageToggle';
+import PublicShell from '@/components/PublicShell';
 import { publicPageMetadata } from '@/util/seo';
 
 export const runtime = 'edge';
@@ -26,12 +26,10 @@ export default async function PrivacyPage({
     const withLang = (path: string) => (lang === 'en' ? `${path}?lang=en` : path);
 
     return (
+        <PublicShell lang={lang}>
         <Container maxWidth="md" sx={{ py: 6 }}>
             <Stack spacing={4}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 2 }}>
-                    <Typography variant="h3" component="h1">{s.title}</Typography>
-                    <LanguageToggle />
-                </Box>
+                <Typography variant="h3" component="h1">{s.title}</Typography>
                 <Typography variant="body2" color="text.secondary">{s.updated}</Typography>
 
                 {s.sections.map((section) => (
@@ -52,5 +50,6 @@ export default async function PrivacyPage({
                 </Box>
             </Stack>
         </Container>
+        </PublicShell>
     );
 }

--- a/src/app/style/customTheme.ts
+++ b/src/app/style/customTheme.ts
@@ -1,15 +1,100 @@
-﻿import {createTheme} from "@mui/material/styles";
+import { createTheme, alpha } from '@mui/material/styles';
+
+// Palette notes:
+// - primary stays a deep green — it doubles as the "valid" color on the
+//   verify page, so it must read as trustworthy/success.
+// - secondary is the pending/neutral accent on the verify page border;
+//   a muted amber instead of pure #FFA500 so it doesn't scream.
+// - warning keeps its historical dark red (used by legacy admin views).
+const green = {
+    main: '#00684A',
+    dark: '#00543C',
+    light: '#3D8B72',
+};
 
 export const customTheme = createTheme({
     palette: {
-        primary: {
-            main: '#006647',
-        },
+        primary: green,
         secondary: {
-            main: '#FFA500',
+            main: '#C77700',
+            dark: '#9E5F00',
+            light: '#E39A2D',
         },
         warning: {
             main: '#761a19',
+        },
+        error: {
+            main: '#B3261E',
+        },
+        background: {
+            default: '#F7F9F8',
+            paper: '#FFFFFF',
+        },
+        text: {
+            primary: '#1C2422',
+            secondary: '#54615C',
+        },
+        divider: '#E3E8E6',
+    },
+    shape: {
+        borderRadius: 10,
+    },
+    typography: {
+        fontFamily: [
+            '-apple-system',
+            'BlinkMacSystemFont',
+            '"Segoe UI"',
+            'Roboto',
+            '"Helvetica Neue"',
+            'Arial',
+            'sans-serif',
+        ].join(','),
+        h1: { fontWeight: 800, letterSpacing: '-0.02em' },
+        h2: { fontWeight: 800, letterSpacing: '-0.02em' },
+        h3: { fontWeight: 700, letterSpacing: '-0.015em' },
+        h4: { fontWeight: 700, letterSpacing: '-0.01em' },
+        h5: { fontWeight: 700 },
+        h6: { fontWeight: 600 },
+        subtitle1: { fontWeight: 600 },
+        button: { fontWeight: 600, textTransform: 'none' },
+    },
+    components: {
+        MuiCssBaseline: {
+            styleOverrides: {
+                // Raw next/link anchors (used all over the public pages)
+                // inherit the browser's default blue otherwise.
+                a: {
+                    color: green.main,
+                    textDecorationColor: alpha(green.main, 0.35),
+                    textUnderlineOffset: '3px',
+                    '&:hover': {
+                        textDecorationColor: green.main,
+                    },
+                },
+            },
+        },
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 999,
+                    paddingLeft: 20,
+                    paddingRight: 20,
+                },
+            },
+        },
+        MuiChip: {
+            styleOverrides: {
+                root: {
+                    fontWeight: 500,
+                },
+            },
+        },
+        MuiPaper: {
+            styleOverrides: {
+                // Softer than MUI's default drop shadows.
+                elevation1: { boxShadow: '0 1px 3px rgba(28,36,34,0.08)' },
+                elevation2: { boxShadow: '0 2px 8px rgba(28,36,34,0.09)' },
+            },
         },
     },
 });

--- a/src/app/style/rootLayout.tsx
+++ b/src/app/style/rootLayout.tsx
@@ -1,11 +1,13 @@
 ﻿'use client'
 import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
 import {customTheme} from "@/app/style/customTheme";
 import { ToastProvider } from '@/components/ToastProvider';
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
     return (
         <ThemeProvider theme={customTheme}>
+            <CssBaseline />
             <ToastProvider>
                 {children}
             </ToastProvider>

--- a/src/components/PublicShell.tsx
+++ b/src/components/PublicShell.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { Box, Container, Divider, Typography } from '@mui/material';
+import LanguageToggle from '@/components/LanguageToggle';
+import { getStrings } from '@/strings';
+
+/**
+ * Shared chrome for the public marketing/info pages (landing, /om,
+ * /personvern): a slim wordmark header with the language toggle, and a
+ * footer with the standard links. The org-branded pages (form, verify)
+ * keep their own headers — the org's identity should lead there, not ours.
+ */
+
+const withLang = (path: string, lang?: string | null) =>
+    lang === 'en' ? `${path}?lang=en` : path;
+
+export function PublicHeader({ lang }: { lang?: string | null }) {
+    return (
+        <Box component="header" sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+            <Container maxWidth="md" sx={{ py: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2 }}>
+                <Typography
+                    component={Link}
+                    href={withLang('/', lang)}
+                    variant="h6"
+                    sx={{ color: 'text.primary', textDecoration: 'none', letterSpacing: '-0.01em' }}
+                >
+                    attester<Box component="span" sx={{ color: 'primary.main' }}>.no</Box>
+                </Typography>
+                <LanguageToggle />
+            </Container>
+        </Box>
+    );
+}
+
+export function PublicFooter({ lang }: { lang?: string | null }) {
+    const s = getStrings(lang);
+    return (
+        <Box component="footer" sx={{ mt: 'auto', bgcolor: 'background.paper' }}>
+            <Container maxWidth="md" sx={{ py: 4 }}>
+                <Divider sx={{ mb: 3 }} />
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2, sm: 4 }, alignItems: 'center', justifyContent: 'space-between' }}>
+                    <Typography variant="body2" color="text.secondary">
+                        attester.no
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2, sm: 3 }, fontSize: '0.875rem' }}>
+                        <Link href={withLang('/om', lang)}>{s.about.metaTitle}</Link>
+                        <Link href={withLang('/personvern', lang)}>{s.privacy.metaTitle}</Link>
+                        <Link href="/login">{s.landing.adminLogin}</Link>
+                        <Link href="https://github.com/ArneeMe/attester.no" target="_blank" rel="noreferrer">
+                            GitHub ↗
+                        </Link>
+                    </Box>
+                </Box>
+            </Container>
+        </Box>
+    );
+}
+
+export default function PublicShell({
+    lang,
+    children,
+}: {
+    lang?: string | null;
+    children: React.ReactNode;
+}) {
+    return (
+        <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+            <PublicHeader lang={lang} />
+            <Box component="main" sx={{ flex: 1 }}>
+                {children}
+            </Box>
+            <PublicFooter lang={lang} />
+        </Box>
+    );
+}


### PR DESCRIPTION
**Last part of the review stack** (on the SEO PR). Pure presentation — no logic, no strings changes, no security surface. Merge this last; everything upstream merges to main first, then this makes it pretty.

## What changed
- **Theme** (`customTheme.ts`): refined deep-green palette (primary doubles as the verify page's "valid" color, so it stays semantic), muted amber secondary instead of pure orange, system font stack with tighter/heavier headings, pill buttons, soft shadows, off-white page background, styled anchor links.
- **`CssBaseline`** added in the root layout — the app never had it, which is why everything looked like unstyled MUI defaults.
- **`PublicShell`** (new): shared slim header (wordmark + single language toggle) and footer (om / personvern / admin login / GitHub) for the landing, `/om` and `/personvern`. The org-branded pages (form, verify) deliberately keep their own headers — the org's identity leads there.
- **Landing rebuilt**: centered hero, numbered step cards, green-accent privacy card with shield icon, outlined org chips, contact line. Admin login moved to the footer.
- `/om` and `/personvern` wrapped in the shell; their duplicate language toggles removed.

## Verification
Typecheck, lint, 110 unit tests, **all 8 Playwright E2E** (landing heading, admin-login link, both language-toggle walks) and production build pass. Check the Cloudflare preview on this PR to see the result live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFHkXUuHJME4cF9AJWbavB)_